### PR TITLE
use quicvarint.Append instead of quicvarint.Write

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package webtransport_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -60,10 +59,10 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 		str, err := conn.AcceptStream(context.Background())
 		require.NoError(t, err)
 		// write a HTTP3 data frame. This will cause an error, since a HEADERS frame is expected
-		b := &bytes.Buffer{}
-		quicvarint.Write(b, 0x0)
-		quicvarint.Write(b, 1337)
-		_, err = str.Write(b.Bytes())
+		var b []byte
+		b = quicvarint.Append(b, 0x0)
+		b = quicvarint.Append(b, 1337)
+		_, err = str.Write(b)
 		require.NoError(t, err)
 		for {
 			if _, err := str.Read(make([]byte, 64)); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,6 @@
 package webtransport_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -72,11 +71,11 @@ func createStreamAndWrite(t *testing.T, qconn http3.StreamCreator, sessionID uin
 	t.Helper()
 	str, err := qconn.OpenStream()
 	require.NoError(t, err)
-	buf := &bytes.Buffer{}
-	quicvarint.Write(buf, 0x41)
-	quicvarint.Write(buf, sessionID) // stream ID of the stream used to establish the WebTransport session.
-	buf.Write(data)
-	_, err = str.Write(buf.Bytes())
+	var buf []byte
+	buf = quicvarint.Append(buf, 0x41)
+	buf = quicvarint.Append(buf, sessionID) // stream ID of the stream used to establish the WebTransport session.
+	buf = append(buf, data...)
+	_, err = str.Write(buf)
 	require.NoError(t, err)
 	require.NoError(t, str.Close())
 	return str

--- a/session.go
+++ b/session.go
@@ -1,7 +1,6 @@
 package webtransport
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -95,15 +94,13 @@ func newSession(sessionID sessionID, qconn http3.StreamCreator, requestStr quic.
 		streams:         *newStreamsMap(),
 	}
 	// precompute the headers for unidirectional streams
-	buf := bytes.NewBuffer(make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID))))
-	quicvarint.Write(buf, webTransportUniStreamType)
-	quicvarint.Write(buf, uint64(c.sessionID))
-	c.uniStreamHdr = buf.Bytes()
+	c.uniStreamHdr = make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID)))
+	c.uniStreamHdr = quicvarint.Append(c.uniStreamHdr, webTransportUniStreamType)
+	c.uniStreamHdr = quicvarint.Append(c.uniStreamHdr, uint64(c.sessionID))
 	// precompute the headers for bidirectional streams
-	buf = bytes.NewBuffer(make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID))))
-	quicvarint.Write(buf, webTransportFrameType)
-	quicvarint.Write(buf, uint64(c.sessionID))
-	c.streamHdr = buf.Bytes()
+	c.streamHdr = make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID)))
+	c.streamHdr = quicvarint.Append(c.streamHdr, webTransportFrameType)
+	c.streamHdr = quicvarint.Append(c.streamHdr, uint64(c.sessionID))
 
 	go func() {
 		defer ctxCancel()


### PR DESCRIPTION
`Append` is faster than `Write`. Probably doesn't matter much here, but doesn't hurt.