### PR TITLE
Add ServeListener function, and override existing webTransportDraftOfferHeaderKey if set

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	if reqHdr == nil {
 		reqHdr = http.Header{}
 	}
-	reqHdr.Add(webTransportDraftOfferHeaderKey, "1")
+	reqHdr.Set(webTransportDraftOfferHeaderKey, "1")
 	req := &http.Request{
 		Method: http.MethodConnect,
 		Header: reqHdr,

--- a/server.go
+++ b/server.go
@@ -116,6 +116,14 @@ func (s *Server) Serve(conn net.PacketConn) error {
 	return s.H3.Serve(conn)
 }
 
+// ServeQUICConn serves an already existing QUIC listener.
+func (s *Server) ServeListener(ln quic.EarlyListener) error {
+	if err := s.initialize(); err != nil {
+		return err
+	}
+	return s.H3.ServeListener(ln)
+}
+
 // ServeQUICConn serves a single QUIC connection.
 func (s *Server) ServeQUICConn(conn quic.Connection) error {
 	if err := s.initialize(); err != nil {


### PR DESCRIPTION
Should allow for listening using a quic.EarlyListener.

As for the latter fix, the current behavior, adding a new value with that header name, can cause issues if it's already set. This may happen if you're retrying the Dial call, reusing the same headers object.