### PR TITLE
replace the WebTransport offer header if already set

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	if reqHdr == nil {
 		reqHdr = http.Header{}
 	}
-	reqHdr.Add(webTransportDraftOfferHeaderKey, "1")
+	reqHdr.Set(webTransportDraftOfferHeaderKey, "1")
 	req := &http.Request{
 		Method: http.MethodConnect,
 		Header: reqHdr,


### PR DESCRIPTION
Dialer.Dial currently adds a new HTTP header (with key set in webTransportDraftOfferHeaderKey) to the passed headers object when called. This can cause issues if the header is already set, which may happen if you're retrying the Dial call reusing the same headers object.