### PR TITLE
chore: bump go.mod to Go 1.20 and run go fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quic-go/webtransport-go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
Taking https://github.com/quic-go/webtransport-go/pull/89 over from @web3-bot 

Requires https://github.com/quic-go/webtransport-go/pull/91