### PR TITLE
add support for datagrams

### DIFF
--- a/mock_stream_creator_test.go
+++ b/mock_stream_creator_test.go
@@ -142,6 +142,21 @@ func (mr *MockStreamCreatorMockRecorder) OpenUniStreamSync(arg0 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenUniStreamSync", reflect.TypeOf((*MockStreamCreator)(nil).OpenUniStreamSync), arg0)
 }
 
+// ReceiveMessage mocks base method.
+func (m *MockStreamCreator) ReceiveMessage(arg0 context.Context) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReceiveMessage", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReceiveMessage indicates an expected call of ReceiveMessage.
+func (mr *MockStreamCreatorMockRecorder) ReceiveMessage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiveMessage", reflect.TypeOf((*MockStreamCreator)(nil).ReceiveMessage), arg0)
+}
+
 // RemoteAddr mocks base method.
 func (m *MockStreamCreator) RemoteAddr() net.Addr {
 	m.ctrl.T.Helper()
@@ -154,4 +169,18 @@ func (m *MockStreamCreator) RemoteAddr() net.Addr {
 func (mr *MockStreamCreatorMockRecorder) RemoteAddr() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteAddr", reflect.TypeOf((*MockStreamCreator)(nil).RemoteAddr))
+}
+
+// SendMessage mocks base method.
+func (m *MockStreamCreator) SendMessage(arg0 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendMessage", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMessage indicates an expected call of SendMessage.
+func (mr *MockStreamCreatorMockRecorder) SendMessage(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessage", reflect.TypeOf((*MockStreamCreator)(nil).SendMessage), arg0)
 }

--- a/session.go
+++ b/session.go
@@ -1,9 +1,11 @@
 package webtransport
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -29,6 +31,11 @@ type acceptQueue[T any] struct {
 	// There's no explicit limit to the length of the queue, but it is implicitly
 	// limited by the stream flow control provided by QUIC.
 	queue []T
+}
+
+type receiveMessageResult struct {
+	msg []byte
+	err error
 }
 
 func newAcceptQueue[T any]() *acceptQueue[T] {
@@ -270,6 +277,43 @@ func (s *Session) AcceptUniStream(ctx context.Context) (ReceiveStream, error) {
 		case <-s.uniAcceptQueue.Chan():
 		}
 	}
+}
+
+func (s *Session) ReceiveMessage(ctx context.Context) ([]byte, error) {
+	resultChannel := make(chan receiveMessageResult)
+	go func() {
+		msg, err := s.qconn.ReceiveMessage(ctx)
+		resultChannel <- receiveMessageResult{msg: msg, err: err}
+	}()
+
+	select {
+	case result := <-resultChannel:
+		if result.err != nil {
+			return nil, result.err
+		}
+
+		datastream := bytes.NewReader(result.msg)
+		quarterStreamId, err := quicvarint.Read(datastream)
+		if err != nil {
+			return nil, err
+		}
+
+		return result.msg[quicvarint.Len(quarterStreamId):], nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("WebTransport stream closed")
+	}
+}
+
+// SendMessage sends a datagram over a WebTransport session.
+// Note that datagrams are unreliable - depending on network conditions, datagrams sent by the server may never be
+// received by the client.
+func (s *Session) SendMessage(msg []byte) error {
+	buf := &bytes.Buffer{}
+
+	// "Quarter Stream ID" (!) of associated request stream, as per https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram
+	buf.Write(quicvarint.Append(nil, uint64(s.requestStr.StreamID()/4)))
+	buf.Write(msg)
+	return s.qconn.SendMessage(buf.Bytes())
 }
 
 func (s *Session) OpenStream() (Stream, error) {


### PR DESCRIPTION
pretty well copy pasta'd from github.com/adriancable/webtransport-go, adds support for datagrams

depends on https://github.com/quic-go/quic-go/pull/4112
resolves https://github.com/quic-go/webtransport-go/issues/8