### PR TITLE
close http3.RoundTripper after test

### DIFF
--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -91,6 +91,7 @@ func establishSession(t *testing.T, handler func(*webtransport.Session)) (sess *
 	return sess, func() {
 		closeServer()
 		s.Close()
+		d.RoundTripper.Close()
 	}
 }
 


### PR DESCRIPTION
Related https://github.com/quic-go/webtransport-go/issues/98