### PR TITLE
Expose Context()

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -1,6 +1,7 @@
 package webtransport
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ type quicSendStream interface {
 	io.WriteCloser
 	StreamID() quic.StreamID
 	CancelWrite(quic.StreamErrorCode)
+	Context() context.Context
 	SetWriteDeadline(time.Time) error
 }
 
@@ -94,6 +96,10 @@ func (s *SendStream) Close() error {
 	}
 	s.onClose()
 	return maybeConvertStreamError(s.str.Close())
+}
+
+func (s *SendStream) Context() context.Context {
+	return s.str.Context()
 }
 
 func (s *SendStream) SetWriteDeadline(t time.Time) error {
@@ -199,6 +205,10 @@ func (s *Stream) registerClose(isSendSide bool) {
 func (s *Stream) closeWithSession() {
 	s.sendStr.closeWithSession()
 	s.recvStr.closeWithSession()
+}
+
+func (s *Stream) Context() context.Context {
+	return s.sendStr.Context()
 }
 
 func (s *Stream) SetWriteDeadline(t time.Time) error {


### PR DESCRIPTION
In the current API, there is no possible way to know that the remote has cancelled an outbound stream (e.g., the remote called `CancelRead`), other than by calling `Send` (which then returns an error).

This behavior is already implemented in `quic-go` via a context that gets cancelled when the reader cancels the stream, so it's sufficient to just expose this context from the webtransport layer.