### PR TITLE
replace Session.ConnectionState with Session.SessionState

### DIFF
--- a/session.go
+++ b/session.go
@@ -446,10 +446,6 @@ func (s *Session) closeWithError(closeErr error) (bool /* first call to close se
 	return true, nil
 }
 
-func (s *Session) ConnectionState() quic.ConnectionState {
-	return s.conn.ConnectionState()
-}
-
 // SessionState returns the current state of the session
 func (s *Session) SessionState() SessionState {
 	return SessionState{


### PR DESCRIPTION
We will expose the negotiated application protocol (see #132) on the `SessionState`.