### PR TITLE
remove closed session from session manager

### DIFF
--- a/session_manager.go
+++ b/session_manager.go
@@ -194,7 +194,6 @@ func (m *sessionManager) AddSession(qconn *http3.Conn, id sessionID, str http3St
 		m.mx.Lock()
 		defer m.mx.Unlock()
 		m.maybeDelete(connTracingID, id)
-		return
 	}()
 	return conn
 }


### PR DESCRIPTION
- We identified a memory leak in the webtransport library that is caused by the session manager not removing webtransport sessions from its field "sessions" even after they are closed. 
- This was causing our server that uses webtransport library (version 0.80, but we have also tested in latest webtransport-go) to leak memory. So we fixed the memory leak by adding code that deletes webtransport sessions from the session manager after their context has been cancelled / its done.
- We also added an auxiliary function NumberActiveWebtransportSessions that returns the number of active webtransport sessions. We use the function to log usage of our server.
- We would like to contribute this fix to webtransport-go in case it helps anyone else. If you need any information let me know @marten-seemann  .
- Note that the memory leak in session manager had  previously been reported in https://github.com/quic-go/webtransport-go/issues/118 .


**Testing information**
- We ran the interop/main.go server and executed python3 interop.py 500 times, both with and without the patch.  Memory usage of interop/main.go **was 76 Megabytes after the execution ended without the patch**, whereas memory usage of  interop/main.go was **24 Megabytes   after the execution ended with the patch**.  In both cases we gave ample time to interop/main.go to garbage collect memory before recording memory usage.
-  We deployed a patched version of the webtransport sesion to our server and noticed that memory leak disappeared without causing any crashes. We have been running the patched version of the webtransport library without any problems for over two months.
- We also executed end-to-end stress tests to our server where a client would repeatedly connect and disconnect. We managed to record that without patch the server would leak substantial memory, whereas with the patch the server would not leak memory.
