### PR TITLE
use the request / dial context on the session

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,10 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019:.+quic\.ConnectionTracing(ID|Key)'
+      - linters:
+          - staticcheck
+        path: _test\.go
+        text: 'SA1029:' # inappropriate key in call to context.WithValue
 formatters:
   enable:
     - gofmt

--- a/client.go
+++ b/client.go
@@ -185,7 +185,8 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
 		protocol = d.negotiateProtocol(protocolHeader)
 	}
-	return rsp, d.conns.AddSession(conn.Conn(), sessionID(requestStr.StreamID()), requestStr, protocol), nil
+	sessID := sessionID(requestStr.StreamID())
+	return rsp, d.conns.AddSession(context.WithoutCancel(ctx), conn.Conn(), sessID, requestStr, protocol), nil
 }
 
 func (d *Dialer) negotiateProtocol(theirs []string) string {

--- a/server.go
+++ b/server.go
@@ -205,7 +205,7 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 
 	str := w.(http3.HTTPStreamer).HTTPStream()
 	sessID := sessionID(str.StreamID())
-	return s.conns.AddSession(conn, sessID, str, selectedProtocol), nil
+	return s.conns.AddSession(context.WithoutCancel(r.Context()), conn, sessID, str, selectedProtocol), nil
 }
 
 func (s *Server) selectProtocol(theirs []string) string {

--- a/session.go
+++ b/session.go
@@ -118,9 +118,9 @@ type Session struct {
 	streams streamsMap
 }
 
-func newSession(sessionID sessionID, conn http3Conn, str http3Stream, applicationProtocol string) *Session {
+func newSession(ctx context.Context, sessionID sessionID, conn http3Conn, str http3Stream, applicationProtocol string) *Session {
 	tracingID := conn.Context().Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
-	ctx, ctxCancel := context.WithCancel(context.WithValue(context.Background(), quic.ConnectionTracingKey, tracingID))
+	ctx, ctxCancel := context.WithCancel(context.WithValue(ctx, quic.ConnectionTracingKey, tracingID))
 	c := &Session{
 		sessionID:           sessionID,
 		conn:                conn,

--- a/session_manager.go
+++ b/session_manager.go
@@ -164,8 +164,8 @@ func (m *sessionManager) handleUniStream(str *quic.ReceiveStream, sess *session)
 }
 
 // AddSession adds a new WebTransport session.
-func (m *sessionManager) AddSession(qconn *http3.Conn, id sessionID, str http3Stream, applicationProtocol string) *Session {
-	conn := newSession(id, qconn, str, applicationProtocol)
+func (m *sessionManager) AddSession(ctx context.Context, qconn *http3.Conn, id sessionID, str http3Stream, applicationProtocol string) *Session {
+	conn := newSession(ctx, id, qconn, str, applicationProtocol)
 	connTracingID := qconn.Context().Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
 
 	m.mx.Lock()

--- a/session_test.go
+++ b/session_test.go
@@ -101,7 +101,7 @@ func setupSession(t *testing.T, clientConn, serverConn *quic.Conn, sessionID ses
 
 	serverAddr := startSimpleWebTransportServer(t, serverConn, &http3.Server{})
 	reqStr, conn := setupRequestStr(t, tr, clientConn, serverAddr)
-	sess = newSession(sessionID, conn.Conn(), reqStr, "")
+	sess = newSession(context.Background(), sessionID, conn.Conn(), reqStr, "")
 	return sess
 }
 
@@ -322,7 +322,7 @@ func testOpenStreamSyncAfterSessionClose(t *testing.T, bidirectional bool) {
 		hijackMagicNumber:   magicNumber,
 		blockOpenStreamSync: unblockOpenStreamSync,
 	}
-	sess := newSession(magicNumber, mockConn, reqStr, "")
+	sess := newSession(context.Background(), magicNumber, mockConn, reqStr, "")
 
 	errChan := make(chan error, 1)
 	switch bidirectional {


### PR DESCRIPTION
This allows the application to attach values to the context:
* on the server side: by modifying the request context
* on the client side: by modifying the context passed to Dial