### PR TITLE
update name of WT_BUFFERED_STREAM_REJECTED error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -48,9 +48,9 @@ func isWebTransportError(e error) bool {
 	return err == nil
 }
 
-// WebTransportBufferedStreamRejectedErrorCode is the error code of the
-// H3_WEBTRANSPORT_BUFFERED_STREAM_REJECTED error.
-const WebTransportBufferedStreamRejectedErrorCode quic.StreamErrorCode = 0x3994bd84
+// WTBufferedStreamRejectedErrorCode is the error code of the
+// WT_BUFFERED_STREAM_REJECTED error.
+const WTBufferedStreamRejectedErrorCode quic.StreamErrorCode = 0x3994bd84
 
 // StreamError is the error that is returned from stream operations (Read, Write) when the stream is canceled.
 type StreamError struct {

--- a/server_test.go
+++ b/server_test.go
@@ -157,7 +157,7 @@ func TestServerReorderedUpgradeRequestTimeout(t *testing.T) {
 	_, err = str.Read([]byte{0})
 	var streamErr *quic.StreamError
 	require.ErrorAs(t, err, &streamErr)
-	require.Equal(t, webtransport.WebTransportBufferedStreamRejectedErrorCode, streamErr.ErrorCode)
+	require.Equal(t, webtransport.WTBufferedStreamRejectedErrorCode, streamErr.ErrorCode)
 
 	// Now establish the session. Make sure we don't accept the stream.
 	requestStr, err := conn.OpenRequestStream(context.Background())
@@ -223,7 +223,7 @@ func TestServerReorderedMultipleStreams(t *testing.T) {
 	_, err = str1.Read([]byte{0})
 	var streamErr *quic.StreamError
 	require.ErrorAs(t, err, &streamErr)
-	require.Equal(t, webtransport.WebTransportBufferedStreamRejectedErrorCode, streamErr.ErrorCode)
+	require.Equal(t, webtransport.WTBufferedStreamRejectedErrorCode, streamErr.ErrorCode)
 	took := time.Since(start)
 	require.GreaterOrEqual(t, took, timeout)
 	require.Less(t, took, timeout*5/4)

--- a/session_manager.go
+++ b/session_manager.go
@@ -142,8 +142,8 @@ func (m *sessionManager) handleStream(str *quic.Stream, sess *session) {
 	case <-sess.created:
 		sess.conn.addIncomingStream(str)
 	case <-t.C:
-		str.CancelRead(WebTransportBufferedStreamRejectedErrorCode)
-		str.CancelWrite(WebTransportBufferedStreamRejectedErrorCode)
+		str.CancelRead(WTBufferedStreamRejectedErrorCode)
+		str.CancelWrite(WTBufferedStreamRejectedErrorCode)
 	case <-m.ctx.Done():
 	}
 }
@@ -158,7 +158,7 @@ func (m *sessionManager) handleUniStream(str *quic.ReceiveStream, sess *session)
 	case <-sess.created:
 		sess.conn.addIncomingUniStream(str)
 	case <-t.C:
-		str.CancelRead(WebTransportBufferedStreamRejectedErrorCode)
+		str.CancelRead(WTBufferedStreamRejectedErrorCode)
 	case <-m.ctx.Done():
 	}
 }


### PR DESCRIPTION
In a recent draft version, H3_WEBTRANSPORT_BUFFERED_STREAM_REJECTED was
renamed to WT_BUFFERED_STREAM_REJECTED error.
const WTBufferedStreamReject.
