### PR TITLE
propagate the session close error to the stream read and write methods

### DIFF
--- a/session.go
+++ b/session.go
@@ -454,7 +454,7 @@ func (s *Session) closeWithError(closeErr error) (bool /* first call to close se
 	for _, cancel := range s.streamCtxs {
 		cancel()
 	}
-	s.streams.CloseSession()
+	s.streams.CloseSession(closeErr)
 
 	return true, nil
 }

--- a/session_test.go
+++ b/session_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:unparam
 func scaleDuration(d time.Duration) time.Duration {
 	if os.Getenv("CI") != "" {
 		return 5 * d

--- a/streams_map.go
+++ b/streams_map.go
@@ -6,7 +6,7 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-type closeFunc func()
+type closeFunc func(error)
 
 // The streamsMap manages the streams of a single QUIC connection.
 // Note that several WebTransport sessions can share one QUIC connection.
@@ -31,12 +31,12 @@ func (s *streamsMap) RemoveStream(id quic.StreamID) {
 	s.mx.Unlock()
 }
 
-func (s *streamsMap) CloseSession() {
+func (s *streamsMap) CloseSession(err error) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
 	for _, cl := range s.m {
-		cl()
+		cl(err)
 	}
 	s.m = nil
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Propagate session close errors to stream read/write by passing the error from `Session.closeWithError` to `streamsMap.CloseSession` and returning it from `SendStream.Write` and `ReceiveStream.Read` on `WTSessionGoneErrorCode` in [stream.go](https://github.com/quic-go/webtransport-go/pull/207/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90) and [session.go](https://github.com/quic-go/webtransport-go/pull/207/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac)
Introduce error-aware session close propagation: `streamsMap.CloseSession(err)` distributes the session error to registered streams, and `SendStream`/`ReceiveStream` block on `WTSessionGoneErrorCode` then return the recorded session close error. Tests cover send/receive behavior and session-driven closure.

#### 📍Where to Start
Start with `Session.closeWithError` in [session.go](https://github.com/quic-go/webtransport-go/pull/207/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac), then review `streamsMap.CloseSession` in [streams_map.go](https://github.com/quic-go/webtransport-go/pull/207/files#diff-666bc646e87db500ba5ef77f336c8fb175703c97cf0b6485012fd65bad83b382), followed by `SendStream`/`ReceiveStream` handling in [stream.go](https://github.com/quic-go/webtransport-go/pull/207/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 5481506.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->