### PR TITLE
respect stream deadline when waititing for session close

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:unparam
 func scaleDuration(d time.Duration) time.Duration {
 	if os.Getenv("CI") != "" {
 		return 5 * d


### PR DESCRIPTION
When streams receive the WT_SESSION_GONE stream reset, streams block Read and Write calls until the CONNECT stream is closed. This allows us to return the error sent in the WT_CLOSE_SESSION capsule.

This PR adds correct handling for read and write deadlines, respectively.