### PR TITLE
embed the http3.Server in the Server as a pointer

### DIFF
--- a/interop/main.go
+++ b/interop/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	wmux := http.NewServeMux()
 	s := webtransport.Server{
-		H3: http3.Server{
+		H3: &http3.Server{
 			TLSConfig: tlsConf,
 			Addr:      "localhost:12345",
 			Handler:   wmux,

--- a/server.go
+++ b/server.go
@@ -30,7 +30,7 @@ const (
 )
 
 type Server struct {
-	H3 http3.Server
+	H3 *http3.Server
 
 	// ApplicationProtocols is a list of application protocols that can be negotiated,
 	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-14 for details.

--- a/server_test.go
+++ b/server_test.go
@@ -62,7 +62,7 @@ func createStreamAndWrite(t *testing.T, conn *quic.Conn, sessionID uint64, data 
 
 func TestServerReorderedUpgradeRequest(t *testing.T) {
 	s := webtransport.Server{
-		H3: http3.Server{TLSConfig: webtransport.TLSConf},
+		H3: &http3.Server{TLSConfig: webtransport.TLSConf},
 	}
 	defer s.Close()
 	connChan := make(chan *webtransport.Session)
@@ -123,7 +123,7 @@ func TestServerReorderedUpgradeRequest(t *testing.T) {
 func TestServerReorderedUpgradeRequestTimeout(t *testing.T) {
 	timeout := scaleDuration(100 * time.Millisecond)
 	s := webtransport.Server{
-		H3:                http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
+		H3:                &http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
 		ReorderingTimeout: timeout,
 	}
 	defer s.Close()
@@ -189,7 +189,7 @@ func TestServerReorderedUpgradeRequestTimeout(t *testing.T) {
 func TestServerReorderedMultipleStreams(t *testing.T) {
 	timeout := scaleDuration(150 * time.Millisecond)
 	s := webtransport.Server{
-		H3:                http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
+		H3:                &http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
 		ReorderingTimeout: timeout,
 	}
 	defer s.Close()
@@ -253,7 +253,7 @@ func TestServerReorderedMultipleStreams(t *testing.T) {
 func TestServerSettingsCheck(t *testing.T) {
 	timeout := scaleDuration(150 * time.Millisecond)
 	s := webtransport.Server{
-		H3:                http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
+		H3:                &http3.Server{TLSConfig: webtransport.TLSConf, EnableDatagrams: true},
 		ReorderingTimeout: timeout,
 	}
 	errChan := make(chan error, 1)
@@ -291,6 +291,6 @@ func TestServerSettingsCheck(t *testing.T) {
 }
 
 func TestImmediateClose(t *testing.T) {
-	s := webtransport.Server{H3: http3.Server{}}
+	s := webtransport.Server{H3: &http3.Server{}}
 	require.NoError(t, s.Close())
 }

--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -45,7 +45,7 @@ func runServer(t *testing.T, s *webtransport.Server) (addr *net.UDPAddr, close f
 
 func establishSession(t *testing.T, handler func(*webtransport.Session)) (sess *webtransport.Session, close func()) {
 	s := &webtransport.Server{
-		H3: http3.Server{
+		H3: &http3.Server{
 			TLSConfig:  webtransport.TLSConf,
 			QUICConfig: &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true},
 		},
@@ -142,7 +142,7 @@ func TestApplicationProtocolNegotiation(t *testing.T) {
 func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverProtocols []string, expected string) {
 	s := &webtransport.Server{
 		ApplicationProtocols: serverProtocols,
-		H3: http3.Server{
+		H3: &http3.Server{
 			TLSConfig:  webtransport.TLSConf,
 			QUICConfig: &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true},
 		},
@@ -353,7 +353,7 @@ func TestUnidirectionalStreams(t *testing.T) {
 func TestMultipleClients(t *testing.T) {
 	const numClients = 5
 	s := &webtransport.Server{
-		H3: http3.Server{TLSConfig: webtransport.TLSConf},
+		H3: &http3.Server{TLSConfig: webtransport.TLSConf},
 	}
 	defer s.Close()
 	addHandler(t, s, newEchoHandler(t))
@@ -546,7 +546,7 @@ func TestCheckOrigin(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			s := &webtransport.Server{
-				H3:          http3.Server{TLSConfig: webtransport.TLSConf},
+				H3:          &http3.Server{TLSConfig: webtransport.TLSConf},
 				CheckOrigin: tc.CheckOrigin,
 			}
 			defer s.Close()
@@ -721,7 +721,7 @@ func TestSessionContextValues(t *testing.T) {
 	)
 
 	s := &webtransport.Server{
-		H3: http3.Server{
+		H3: &http3.Server{
 			TLSConfig:  webtransport.TLSConf,
 			QUICConfig: &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true},
 		},


### PR DESCRIPTION
Otherwise, it’s not possible to use an already constructed `http3.Server`, as the `http3.Server` contains a mutex.