### PR TITLE
respect the dial timeout when waiting for the server’s HTTP/3 settings

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,6 +148,8 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	conn := tr.NewClientConn(qconn)
 	select {
 	case <-conn.ReceivedSettings():
+	case <-ctx.Done():
+		return nil, nil, fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))
 	case <-d.ctx.Done():
 		return nil, nil, context.Cause(d.ctx)
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Respect dial timeout by canceling `Dialer.Dial` during HTTP/3 settings wait in [client.go](https://github.com/quic-go/webtransport-go/pull/216/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf)
Add a `ctx.Done()` case to the `Dialer.Dial` select that returns `fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))`; add a test for cancellation cause in [client_test.go](https://github.com/quic-go/webtransport-go/pull/216/files#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3).

#### 📍Where to Start
Start in `Dialer.Dial` at the select waiting on `conn.ReceivedSettings()` in [client.go](https://github.com/quic-go/webtransport-go/pull/216/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d54c9fd. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->