### PR TITLE
set a 10ms write deadline before sending the WT_CLOSE_SESSION capsule

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -113,8 +113,10 @@ func (m *mockHTTP3Stream) Close() error {
 func (m *mockHTTP3Stream) ReceiveDatagram(context.Context) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *mockHTTP3Stream) SendDatagram([]byte) error       { return nil }
-func (m *mockHTTP3Stream) CancelRead(quic.StreamErrorCode) {}
+func (m *mockHTTP3Stream) SendDatagram([]byte) error        { return nil }
+func (m *mockHTTP3Stream) CancelRead(quic.StreamErrorCode)  {}
+func (m *mockHTTP3Stream) CancelWrite(quic.StreamErrorCode) {}
+func (m *mockHTTP3Stream) SetWriteDeadline(time.Time) error { return nil }
 
 func setupSession(t *testing.T, clientConn *quic.Conn, sessID sessionID) *Session {
 	mockStr := newMockHTTP3Stream()


### PR DESCRIPTION
If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits. There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.