### PR TITLE
simplify stream buffering logic in the session manager

### DIFF
--- a/session_manager.go
+++ b/session_manager.go
@@ -6,169 +6,121 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
-	"github.com/quic-go/quic-go/quicvarint"
 )
 
-// session is the map value in the conns map
-type session struct {
-	created chan struct{} // is closed once the session map has been initialized
-	counter int           // how many streams are waiting for this session to be established
-	sess    *Session
+type unestablishedSession struct {
+	Streams    []*quic.Stream
+	UniStreams []*quic.ReceiveStream
+
+	Timer *time.Timer
 }
 
-type connEntry struct {
-	conn     *quic.Conn
-	sessions map[sessionID]*session
+type sessionEntry struct {
+	// at any point in time, only one of these will be non-nil
+	Unestablished *unestablishedSession
+	Session       *Session
 }
 
 type sessionManager struct {
-	refCount  sync.WaitGroup
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-
 	timeout time.Duration
 
 	mx    sync.Mutex
-	conns map[*quic.Conn]connEntry
+	conns map[*quic.Conn]map[sessionID]sessionEntry
 }
 
 func newSessionManager(timeout time.Duration) *sessionManager {
-	m := &sessionManager{
+	return &sessionManager{
 		timeout: timeout,
-		conns:   make(map[*quic.Conn]connEntry),
+		conns:   make(map[*quic.Conn]map[sessionID]sessionEntry),
 	}
-	m.ctx, m.ctxCancel = context.WithCancel(context.Background())
-	return m
 }
 
 // AddStream adds a new bidirectional stream to a WebTransport session.
 // If the WebTransport session has not yet been established,
-// it starts a new go routine and waits for establishment of the session.
+// it starts a new Goroutine and waits for establishment of the session.
 // If that takes longer than timeout, the stream is reset.
 func (m *sessionManager) AddStream(conn *quic.Conn, str *quic.Stream, id sessionID) {
-	sess, isExisting := m.getOrCreateSession(conn, id)
-	if isExisting {
-		sess.sess.addIncomingStream(str)
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	entry := m.getOrCreateSession(conn, id)
+	if entry.Session != nil {
+		entry.Session.addIncomingStream(str)
 		return
 	}
 
-	m.refCount.Add(1)
-	go func() {
-		defer m.refCount.Done()
-		m.handleStream(str, sess)
-
-		m.mx.Lock()
-		defer m.mx.Unlock()
-
-		sess.counter--
-		// Once no more streams are waiting for this session to be established,
-		// and this session is still outstanding, delete it from the map.
-		if sess.counter == 0 && sess.sess == nil {
-			m.maybeDelete(conn, id)
-		}
-	}()
-}
-
-func (m *sessionManager) maybeDelete(conn *quic.Conn, id sessionID) {
-	entry, ok := m.conns[conn]
-	if !ok { // should never happen
-		return
-	}
-	delete(entry.sessions, id)
-	if len(entry.sessions) == 0 {
-		delete(m.conns, conn)
-	}
+	entry.Unestablished.Streams = append(entry.Unestablished.Streams, str)
+	m.resetTimer(entry, conn, id)
 }
 
 // AddUniStream adds a new unidirectional stream to a WebTransport session.
 // If the WebTransport session has not yet been established,
-// it starts a new go routine and waits for establishment of the session.
+// it starts a new Goroutine and waits for establishment of the session.
 // If that takes longer than timeout, the stream is reset.
-func (m *sessionManager) AddUniStream(conn *quic.Conn, str *quic.ReceiveStream) {
-	idv, err := quicvarint.Read(quicvarint.NewReader(str))
-	if err != nil {
-		str.CancelRead(1337)
-		return
-	}
-	id := sessionID(idv)
+func (m *sessionManager) AddUniStream(conn *quic.Conn, str *quic.ReceiveStream, id sessionID) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
 
-	sess, isExisting := m.getOrCreateSession(conn, id)
-	if isExisting {
-		sess.sess.addIncomingUniStream(str)
+	entry := m.getOrCreateSession(conn, id)
+	if entry.Session != nil {
+		entry.Session.addIncomingUniStream(str)
 		return
 	}
 
-	m.refCount.Add(1)
-	go func() {
-		defer m.refCount.Done()
-		m.handleUniStream(str, sess)
-
-		m.mx.Lock()
-		defer m.mx.Unlock()
-
-		sess.counter--
-		// Once no more streams are waiting for this session to be established,
-		// and this session is still outstanding, delete it from the map.
-		if sess.counter == 0 && sess.sess == nil {
-			m.maybeDelete(conn, id)
-		}
-	}()
+	entry.Unestablished.UniStreams = append(entry.Unestablished.UniStreams, str)
+	m.resetTimer(entry, conn, id)
 }
 
-func (m *sessionManager) getOrCreateSession(conn *quic.Conn, id sessionID) (sess *session, existed bool) {
+func (m *sessionManager) resetTimer(entry *sessionEntry, conn *quic.Conn, id sessionID) {
+	if entry.Unestablished.Timer != nil {
+		entry.Unestablished.Timer.Reset(m.timeout)
+		return
+	}
+	entry.Unestablished.Timer = time.AfterFunc(m.timeout, func() { m.onTimer(conn, id) })
+}
+
+func (m *sessionManager) onTimer(conn *quic.Conn, id sessionID) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
 	entry, ok := m.conns[conn]
-	if !ok {
-		entry = connEntry{
-			conn:     conn,
-			sessions: make(map[sessionID]*session),
-		}
-		m.conns[conn] = entry
+	if !ok { // connection already closed
+		return
 	}
-
-	sess, ok = entry.sessions[id]
-	if ok && sess.sess != nil {
-		return sess, true
+	sessionEntry, ok := entry[id]
+	if !ok { // session already closed
+		return
 	}
-	if !ok {
-		sess = &session{created: make(chan struct{})}
-		entry.sessions[id] = sess
+	if sessionEntry.Session != nil { // session already established
+		return
 	}
-	sess.counter++
-	return sess, false
-}
-
-func (m *sessionManager) handleStream(str *quic.Stream, sess *session) {
-	t := time.NewTimer(m.timeout)
-	defer t.Stop()
-
-	// When multiple streams are waiting for the same session to be established,
-	// the timeout is calculated for every stream separately.
-	select {
-	case <-sess.created:
-		sess.sess.addIncomingStream(str)
-	case <-t.C:
+	for _, str := range sessionEntry.Unestablished.Streams {
 		str.CancelRead(WTBufferedStreamRejectedErrorCode)
 		str.CancelWrite(WTBufferedStreamRejectedErrorCode)
-	case <-m.ctx.Done():
+	}
+	for _, uniStr := range sessionEntry.Unestablished.UniStreams {
+		uniStr.CancelRead(WTBufferedStreamRejectedErrorCode)
+	}
+	delete(entry, id)
+	if len(entry) == 0 {
+		delete(m.conns, conn)
 	}
 }
 
-func (m *sessionManager) handleUniStream(str *quic.ReceiveStream, sess *session) {
-	t := time.NewTimer(m.timeout)
-	defer t.Stop()
-
-	// When multiple streams are waiting for the same session to be established,
-	// the timeout is calculated for every stream separately.
-	select {
-	case <-sess.created:
-		sess.sess.addIncomingUniStream(str)
-	case <-t.C:
-		str.CancelRead(WTBufferedStreamRejectedErrorCode)
-	case <-m.ctx.Done():
+func (m *sessionManager) getOrCreateSession(conn *quic.Conn, id sessionID) *sessionEntry {
+	sessionMap, ok := m.conns[conn]
+	if !ok {
+		sessionMap = make(map[sessionID]sessionEntry)
+		m.conns[conn] = sessionMap
 	}
+
+	entry, ok := sessionMap[id]
+	if ok {
+		return &entry
+	}
+	entry = sessionEntry{Unestablished: &unestablishedSession{}}
+	sessionMap[id] = entry
+	return &entry
 }
 
 // AddSession adds a new WebTransport session.
@@ -176,39 +128,53 @@ func (m *sessionManager) AddSession(ctx context.Context, conn *quic.Conn, id ses
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
-	entry, ok := m.conns[conn]
+	sessionMap, ok := m.conns[conn]
 	if !ok {
-		entry = connEntry{
-			conn:     conn,
-			sessions: make(map[sessionID]*session),
-		}
-		m.conns[conn] = entry
+		sessionMap = make(map[sessionID]sessionEntry)
+		m.conns[conn] = sessionMap
 	}
+	entry, ok := sessionMap[id]
+
 	s := newSession(ctx, id, conn, str, applicationProtocol)
-
-	if sess, ok := entry.sessions[id]; ok {
+	if ok && entry.Unestablished != nil {
 		// We might already have an entry of this session.
-		// This can happen when we receive a stream for this WebTransport session before we complete
-		// the HTTP request (that establishes the session).
-		sess.sess = s
-		close(sess.created)
-		return s
+		// This can happen when we receive streams for this WebTransport session before we complete
+		// the Extended CONNECT request.
+		for _, str := range entry.Unestablished.Streams {
+			s.addIncomingStream(str)
+		}
+		for _, uniStr := range entry.Unestablished.UniStreams {
+			s.addIncomingUniStream(uniStr)
+		}
+		if entry.Unestablished.Timer != nil {
+			entry.Unestablished.Timer.Stop()
+		}
+		entry.Unestablished = nil
 	}
-	c := make(chan struct{})
-	close(c)
-	entry.sessions[id] = &session{created: c, sess: s}
+	sessionMap[id] = sessionEntry{Session: s}
 
-	// Delete the webtransport session from the session manager once its context is cancalled.
-	go func() {
-		<-conn.Context().Done()
+	context.AfterFunc(s.Context(), func() {
 		m.mx.Lock()
 		defer m.mx.Unlock()
-		m.maybeDelete(conn, id)
-	}()
+		delete(sessionMap, id)
+		if len(sessionMap) == 0 {
+			delete(m.conns, conn)
+		}
+	})
+
 	return s
 }
 
 func (m *sessionManager) Close() {
-	m.ctxCancel()
-	m.refCount.Wait()
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	for conn, sessionMap := range m.conns {
+		for _, entry := range sessionMap {
+			if entry.Unestablished != nil && entry.Unestablished.Timer != nil {
+				entry.Unestablished.Timer.Stop()
+			}
+		}
+		delete(m.conns, conn)
+	}
 }


### PR DESCRIPTION
Due to packet reordering, streams might be received for a session that was not yet established. In that case, we buffer them for a limited amount of time.

This change adjusts the timer logic. Instead of running a timer per stream, we now run one timer per (unestablished) session. This means that streams might potentially be buffered for a longer time, but it simplifies the logic. It's not a security risk, since the total number is still limited by the stream limit on the QUIC layer.