### PR TITLE
remove stray TODO from Session

### DIFF
--- a/session.go
+++ b/session.go
@@ -105,7 +105,6 @@ type Session struct {
 	bidiAcceptQueue acceptQueue[*Stream]
 	uniAcceptQueue  acceptQueue[*ReceiveStream]
 
-	// TODO: garbage collect streams from when they are closed
 	streams streamsMap
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove stray TODO comment from `Session` struct in [session.go](https://github.com/quic-go/webtransport-go/pull/232/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) to clean up documentation
Delete an obsolete TODO about garbage-collecting closed streams from the `Session` struct in [session.go](https://github.com/quic-go/webtransport-go/pull/232/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac).

#### 📍Where to Start
Start at the `Session` struct definition in [session.go](https://github.com/quic-go/webtransport-go/pull/232/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 48e6a02.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->