### PR TITLE
add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@ Please **DO NOT file a public issue** for exploitable vulnerabilities.
 
 If the issue is theoretical, non-exploitable, or related to an experimental feature, you may discuss it openly by filing a regular issue.
 
-## Reporting a non security bug
+## Reporting a non-security bug
 
 For bugs, feature requests, or other non-security concerns, please open a GitHub [issue](https://github.com/quic-go/webtransport-go/issues/new).


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add SECURITY.md to define private reporting via GitHub security advisories and public discussion rules for non-exploitable issues
Introduce a repository-level security policy in [SECURITY.md](https://github.com/quic-go/webtransport-go/pull/233/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7) that directs exploitable vulnerability reports to GitHub security advisories and routes theoretical or non-security topics to regular issues.

#### 📍Where to Start
Start with the policy details in [SECURITY.md](https://github.com/quic-go/webtransport-go/pull/233/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 299df51.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->