### PR TITLE
ci: update golangci-lint to v2.7.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout=3m
-          version: v2.1.6
+          version: v2.7.2


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update GitHub Actions lint workflow to run golangci-lint-action v2.7.2 in [lint.yml](https://github.com/quic-go/webtransport-go/pull/234/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2)
Bump the `version` input of `golangci-lint-action` from `v2.1.6` to `v2.7.2` in [lint.yml](https://github.com/quic-go/webtransport-go/pull/234/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2).

#### 📍Where to Start
Start with the `golangci-lint` step in [lint.yml](https://github.com/quic-go/webtransport-go/pull/234/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 560116f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->