### PR TITLE
update quic-go to v0.59.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/dunglas/httpsfv v1.1.0
-	github.com/quic-go/quic-go v0.58.1-0.20260103101554-29b1a154ebc8
+	github.com/quic-go/quic-go v0.59.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.58.1-0.20260103101554-29b1a154ebc8 h1:5tj3IFn2lUw0063zA+91YC8Vsg2uTbJEggwOcmi5xMA=
-github.com/quic-go/quic-go v0.58.1-0.20260103101554-29b1a154ebc8/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
+github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/session_test.go
+++ b/session_test.go
@@ -75,7 +75,7 @@ func newConnPair(t *testing.T, clientConn, serverConn net.PacketConn) (client, s
 		&quic.Config{EnableDatagrams: true},
 	)
 	require.NoError(t, err)
-	require.True(t, cl.ConnectionState().SupportsDatagrams)
+	require.True(t, cl.ConnectionState().SupportsDatagrams.Remote)
 	t.Cleanup(func() { cl.CloseWithError(0, "") })
 
 	conn, err := ln.Accept(ctx)
@@ -83,7 +83,7 @@ func newConnPair(t *testing.T, clientConn, serverConn net.PacketConn) (client, s
 	t.Cleanup(func() { conn.CloseWithError(0, "") })
 	select {
 	case <-conn.HandshakeComplete():
-		require.True(t, conn.ConnectionState().SupportsDatagrams)
+		require.True(t, conn.ConnectionState().SupportsDatagrams.Remote)
 	case <-ctx.Done():
 		t.Fatal("timeout")
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update QUIC transport to quic-go v0.59.0 and adjust `session_test.go` to assert `ConnectionState().SupportsDatagrams.Remote` for client and server
Bump `github.com/quic-go/quic-go` to v0.59.0 in `go.mod`/`go.sum`, and update test assertions in [session_test.go](https://github.com/quic-go/webtransport-go/pull/240/files#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557) to check `ConnectionState().SupportsDatagrams.Remote` after handshake for both endpoints.

#### 📍Where to Start
Start with the test changes in [session_test.go](https://github.com/quic-go/webtransport-go/pull/240/files#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557), focusing on assertions using `ConnectionState().SupportsDatagrams.Remote`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 843dbce.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->