### PR TITLE
use the WT_REQUIREMENTS_NOT_MET error

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,8 +18,6 @@ import (
 	"github.com/dunglas/httpsfv"
 )
 
-var errNoWebTransport = errors.New("server didn't enable WebTransport")
-
 type Dialer struct {
 	// TLSClientConfig is the TLS client config used when dialing the QUIC connection.
 	// It must set the h3 ALPN.
@@ -121,9 +119,14 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	tr := &http3.Transport{EnableDatagrams: true}
 	rsp, sess, err := d.handleConn(ctx, tr, qconn, req)
 	if err != nil {
-		// TODO: use a more specific error code
-		// see https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http3/issues/245
-		qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "")
+		var msg string
+		code := quic.ApplicationErrorCode(http3.ErrCodeNoError)
+		var reqErr *RequirementsNotMetError
+		if errors.As(err, &reqErr) {
+			code = WTRequirementsNotMetErrorCode
+			msg = reqErr.Message
+		}
+		qconn.CloseWithError(code, msg)
 		tr.Close()
 		return rsp, nil, err
 	}
@@ -214,17 +217,17 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 	}
 	settings := conn.Settings()
 	if !settings.EnableExtendedConnect {
-		return nil, nil, errors.New("server didn't enable Extended CONNECT")
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable Extended CONNECT"}
 	}
 	if !settings.EnableDatagrams {
-		return nil, nil, errors.New("server didn't enable HTTP/3 datagram support")
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable HTTP/3 datagram support"}
 	}
 	if settings.Other == nil {
-		return nil, nil, errNoWebTransport
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
 	s, ok := settings.Other[settingsEnableWebtransport]
 	if !ok || s != 1 {
-		return nil, nil, errNoWebTransport
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
 
 	requestStr, err := conn.OpenRequestStream(ctx)

--- a/client_test.go
+++ b/client_test.go
@@ -221,6 +221,8 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 			_, _, err = d.Dial(context.Background(), fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port), nil)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.errorStr)
+			var reqErr *webtransport.RequirementsNotMetError
+			require.ErrorAs(t, err, &reqErr)
 
 			var serverConn *quic.Conn
 			select {
@@ -234,7 +236,7 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 			case <-serverConn.Context().Done():
 				require.ErrorIs(t,
 					context.Cause(serverConn.Context()),
-					&quic.ApplicationError{ErrorCode: quic.ApplicationErrorCode(http3.ErrCodeNoError), Remote: true},
+					&quic.ApplicationError{ErrorCode: webtransport.WTRequirementsNotMetErrorCode, Remote: true},
 				)
 			case <-time.After(time.Second):
 				t.Fatal("timeout waiting for client to close connection")

--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,10 @@ const (
 
 	// WTSessionGoneErrorCode is the error code of the WT_SESSION_GONE error.
 	WTSessionGoneErrorCode quic.StreamErrorCode = 0x170d7b68
+
+	// WTRequirementsNotMetErrorCode is the error code of the
+	// WT_REQUIREMENTS_NOT_MET error.
+	WTRequirementsNotMetErrorCode quic.ApplicationErrorCode = 0x212c0d48
 )
 
 // StreamError is the error that is returned from stream operations (Read, Write) when the stream is canceled.
@@ -74,3 +78,13 @@ func (e *SessionError) Is(target error) bool {
 	t, ok := target.(*SessionError)
 	return ok && e.ErrorCode == t.ErrorCode && e.Remote == t.Remote
 }
+
+// RequirementsNotMetError is returned when the peer doesn't advertise
+// the required HTTP/3 or WebTransport capabilities.
+type RequirementsNotMetError struct {
+	Message string
+}
+
+var _ error = &RequirementsNotMetError{}
+
+func (e *RequirementsNotMetError) Error() string { return e.Message }


### PR DESCRIPTION
Fixes #247.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `WT_REQUIREMENTS_NOT_MET` error code when closing QUIC connections on unmet WebTransport requirements
> - Adds `WTRequirementsNotMetErrorCode` (0x212c0d48) and a `RequirementsNotMetError` type in [errors.go](https://github.com/quic-go/webtransport-go/pull/252/files#diff-76a7e0e299c7417bae32d3098e71370980157fe29e68a366671491d147d40572).
> - `Dialer.handleConn` now returns `RequirementsNotMetError` when Extended CONNECT, HTTP/3 DATAGRAMs, or WebTransport settings are missing.
> - `Dialer.Dial` inspects the error and closes the QUIC connection with `WTRequirementsNotMetErrorCode` and the error message instead of `ErrCodeNoError` when requirements are unmet.
> - Behavioral Change: servers observing a client disconnect after failed capability negotiation will now see `WTRequirementsNotMetErrorCode` instead of `ErrCodeNoError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ccbb77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->