### PR TITLE
use SETTINGS_WT_ENABLED introduced in draft-15

### DIFF
--- a/client.go
+++ b/client.go
@@ -225,8 +225,9 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 	if settings.Other == nil {
 		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
-	s, ok := settings.Other[settingsEnableWebtransport]
-	if !ok || s != 1 {
+	// any non-zero value for SETTINGS_WT_ENABLED means that WebTransport is enabled
+	s, ok := settings.Other[settingsWebTransportEnabled]
+	if !ok || s == 0 {
 		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ const (
 	// HTTP Datagrams, RFC 9297
 	settingDatagram = 0x33
 	// WebTransport
-	settingsEnableWebtransport = 0x2b603742
+	settingsWebTransportEnabled = 0x2c7cf000
 )
 
 // appendSettingsFrame serializes an HTTP/3 SETTINGS frame
@@ -63,9 +63,9 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 			return
 		}
 		_, err = settingsStr.Write(appendSettingsFrame([]byte{0} /* stream type */, map[uint64]uint64{
-			settingDatagram:            1,
-			settingExtendedConnect:     1,
-			settingsEnableWebtransport: 1,
+			settingDatagram:             1,
+			settingExtendedConnect:      1,
+			settingsWebTransportEnabled: 1,
 		}))
 		if err != nil {
 			errChan <- err
@@ -167,27 +167,27 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 		{
 			name: "Extended CONNECT disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            1,
-				settingExtendedConnect:     0,
-				settingsEnableWebtransport: 1,
+				settingDatagram:             1,
+				settingExtendedConnect:      0,
+				settingsWebTransportEnabled: 1,
 			},
 			errorStr: "server didn't enable Extended CONNECT",
 		},
 		{
 			name: "HTTP/3 DATAGRAMs disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            0,
-				settingExtendedConnect:     1,
-				settingsEnableWebtransport: 1,
+				settingDatagram:             0,
+				settingExtendedConnect:      1,
+				settingsWebTransportEnabled: 1,
 			},
 			errorStr: "server didn't enable HTTP/3 datagram support",
 		},
 		{
 			name: "WebTransport disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            1,
-				settingExtendedConnect:     1,
-				settingsEnableWebtransport: 0,
+				settingDatagram:             1,
+				settingExtendedConnect:      1,
+				settingsWebTransportEnabled: 0,
 			},
 			errorStr: "server didn't enable WebTransport",
 		},
@@ -243,4 +243,67 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientAcceptsPositiveWebTransportSetting(t *testing.T) {
+	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true})
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errChan := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept(context.Background())
+		if err != nil {
+			errChan <- err
+			return
+		}
+		settingsStr, err := conn.OpenUniStream()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		_, err = settingsStr.Write(appendSettingsFrame([]byte{0} /* stream type */, map[uint64]uint64{
+			settingDatagram:             1,
+			settingExtendedConnect:      1,
+			settingsWebTransportEnabled: 2,
+		}))
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		str, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			errChan <- err
+			return
+		}
+		// write an HTTP/3 data frame. This causes an error, since a HEADERS frame is expected.
+		var b []byte
+		b = quicvarint.Append(b, 0x0)
+		b = quicvarint.Append(b, 1337)
+		_, err = str.Write(b)
+		require.NoError(t, err)
+		for {
+			if _, err := str.Read(make([]byte, 64)); err != nil {
+				errChan <- err
+				return
+			}
+		}
+	}()
+
+	d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+	_, _, err = d.Dial(context.Background(), fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port), nil)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "server didn't enable WebTransport")
+
+	var sErr error
+	select {
+	case sErr = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.Error(t, sErr)
+	var appErr *quic.ApplicationError
+	require.True(t, errors.As(sErr, &appErr))
+	require.Equal(t, http3.ErrCodeFrameUnexpected, http3.ErrCode(appErr.ErrorCode))
 }

--- a/protocol.go
+++ b/protocol.go
@@ -1,5 +1,10 @@
 package webtransport
 
-const settingsEnableWebtransport = 0x2b603742
+// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
+// that was used up until draft-ietf-webtrans-http3-06.
+const settingsEnableWebtransportDraft06 = 0x2b603742
+
+// settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
+const settingsWebTransportEnabled = 0x2c7cf000
 
 const protocolHeader = "webtransport"

--- a/server.go
+++ b/server.go
@@ -37,9 +37,11 @@ var quicConnKey = quicConnKeyType{}
 
 func ConfigureHTTP3Server(s *http3.Server) {
 	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64, 1)
+		s.AdditionalSettings = make(map[uint64]uint64, 2)
 	}
-	s.AdditionalSettings[settingsEnableWebtransport] = 1
+	// send the old setting for backwards compatibility with older clients
+	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
+	s.AdditionalSettings[settingsWebTransportEnabled] = 1
 	s.EnableDatagrams = true
 	origConnContext := s.ConnContext
 	s.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Use `SETTINGS_WT_ENABLED` from draft-15 for WebTransport negotiation
- Adds `settingsWebTransportEnabled` (0x2c7cf000) constant in [protocol.go](https://github.com/quic-go/webtransport-go/pull/253/files#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38) alongside the legacy `settingsEnableWebtransportDraft06` (0x2b603742)
- `ConfigureHTTP3Server` in [server.go](https://github.com/quic-go/webtransport-go/pull/253/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6) now advertises both the legacy and new SETTINGS keys, ensuring compatibility with both draft-06 and draft-15 peers
- The client in [client.go](https://github.com/quic-go/webtransport-go/pull/253/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf) now checks the new `SETTINGS_WT_ENABLED` key and treats any non-zero value as enabled (previously required exactly `1`)
- Behavioral Change: clients will no longer recognize the old `ENABLE_WEBTRANSPORT` key for inbound settings; servers that only advertise the legacy key will be treated as not supporting WebTransport

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23e2490.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->