### PR TITLE
use SETTINGS_WT_ENABLED introduced in draft-15

### DIFF
--- a/client.go
+++ b/client.go
@@ -225,8 +225,9 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 	if settings.Other == nil {
 		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
-	s, ok := settings.Other[settingsEnableWebtransport]
-	if !ok || s != 1 {
+	// any non-zero value for SETTINGS_WT_ENABLED means that WebTransport is enabled
+	s, ok := settings.Other[settingsWebTransportEnabled]
+	if !ok || s == 0 {
 		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -25,7 +25,7 @@ const (
 	// HTTP Datagrams, RFC 9297
 	settingDatagram = 0x33
 	// WebTransport
-	settingsEnableWebtransport = 0x2b603742
+	settingsWebTransportEnabled = 0x2c7cf000
 )
 
 // appendSettingsFrame serializes an HTTP/3 SETTINGS frame
@@ -63,9 +63,9 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 			return
 		}
 		_, err = settingsStr.Write(appendSettingsFrame([]byte{0} /* stream type */, map[uint64]uint64{
-			settingDatagram:            1,
-			settingExtendedConnect:     1,
-			settingsEnableWebtransport: 1,
+			settingDatagram:             1,
+			settingExtendedConnect:      1,
+			settingsWebTransportEnabled: 1,
 		}))
 		if err != nil {
 			errChan <- err
@@ -167,27 +167,27 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 		{
 			name: "Extended CONNECT disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            1,
-				settingExtendedConnect:     0,
-				settingsEnableWebtransport: 1,
+				settingDatagram:             1,
+				settingExtendedConnect:      0,
+				settingsWebTransportEnabled: 1,
 			},
 			errorStr: "server didn't enable Extended CONNECT",
 		},
 		{
 			name: "HTTP/3 DATAGRAMs disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            0,
-				settingExtendedConnect:     1,
-				settingsEnableWebtransport: 1,
+				settingDatagram:             0,
+				settingExtendedConnect:      1,
+				settingsWebTransportEnabled: 1,
 			},
 			errorStr: "server didn't enable HTTP/3 datagram support",
 		},
 		{
 			name: "WebTransport disabled",
 			settings: map[uint64]uint64{
-				settingDatagram:            1,
-				settingExtendedConnect:     1,
-				settingsEnableWebtransport: 0,
+				settingDatagram:             1,
+				settingExtendedConnect:      1,
+				settingsWebTransportEnabled: 0,
 			},
 			errorStr: "server didn't enable WebTransport",
 		},

--- a/protocol.go
+++ b/protocol.go
@@ -1,5 +1,10 @@
 package webtransport
 
-const settingsEnableWebtransport = 0x2b603742
+// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
+// that was used up until draft-ietf-webtrans-http3-06.
+const settingsEnableWebtransportDraft06 = 0x2b603742
+
+// settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
+const settingsWebTransportEnabled = 0x2c7cf000
 
 const protocolHeader = "webtransport"

--- a/server.go
+++ b/server.go
@@ -37,9 +37,11 @@ var quicConnKey = quicConnKeyType{}
 
 func ConfigureHTTP3Server(s *http3.Server) {
 	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64, 1)
+		s.AdditionalSettings = make(map[uint64]uint64, 2)
 	}
-	s.AdditionalSettings[settingsEnableWebtransport] = 1
+	// send the old setting for backwards compatibility with older clients
+	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
+	s.AdditionalSettings[settingsWebTransportEnabled] = 1
 	s.EnableDatagrams = true
 	origConnContext := s.ConnContext
 	s.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {


### PR DESCRIPTION
Recreating #253, which was removed by force-push.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `SETTINGS_WT_ENABLED` codepoint from WebTransport draft-15
> - Adds `settingsWebTransportEnabled` (codepoint `0x2c7cf000`) alongside the legacy `settingsEnableWebtransportDraft06` (`0x2b603742`) in [protocol.go](https://github.com/quic-go/webtransport-go/pull/254/files#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38).
> - The server now advertises both settings to maintain backward compatibility with older clients.
> - The client accepts `SETTINGS_WT_ENABLED` with any non-zero value (previously required the legacy codepoint with value exactly `1`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b060a3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->