### PR TITLE
use an iterator to close streams in the streams map

### DIFF
--- a/session.go
+++ b/session.go
@@ -441,8 +441,9 @@ func (s *Session) closeWithError(closeErr error) (bool /* first call to close se
 	for _, cancel := range s.streamCtxs {
 		cancel()
 	}
-	s.streams.CloseSession(closeErr)
-
+	for _, closeFn := range s.streams.All() {
+		closeFn(closeErr)
+	}
 	return true, nil
 }
 

--- a/streams_map.go
+++ b/streams_map.go
@@ -1,6 +1,7 @@
 package webtransport
 
 import (
+	"iter"
 	"sync"
 
 	"github.com/quic-go/quic-go"
@@ -31,12 +32,15 @@ func (s *streamsMap) RemoveStream(id quic.StreamID) {
 	s.mx.Unlock()
 }
 
-func (s *streamsMap) CloseSession(err error) {
-	s.mx.Lock()
-	defer s.mx.Unlock()
+func (s *streamsMap) All() iter.Seq2[quic.StreamID, closeFunc] {
+	return func(yield func(quic.StreamID, closeFunc) bool) {
+		s.mx.Lock()
+		defer s.mx.Unlock()
 
-	for _, cl := range s.m {
-		cl(err)
+		for id, close := range s.m {
+			if !yield(id, close) {
+				return
+			}
+		}
 	}
-	s.m = nil
 }


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `streamsMap.CloseSession` with an `All()` iterator in `Session.closeWithError`
> - Adds an `All()` iterator method to `streamsMap` (in [streams_map.go](https://github.com/quic-go/webtransport-go/pull/257/files#diff-666bc646e87db500ba5ef77f336c8fb175703c97cf0b6485012fd65bad83b382)) that yields each `(streamID, closeFunc)` pair under a lock, without invoking close functions or clearing the map.
> - Updates `Session.closeWithError` (in [session.go](https://github.com/quic-go/webtransport-go/pull/257/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac)) to iterate over `streams.All()` and call each close function directly, replacing the removed `CloseSession` method.
> - Behavioral Change: `CloseSession` previously cleared the internal map to `nil` after closing streams; the new approach leaves map cleanup to the caller's iteration flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db12509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->