### PR TITLE
refactor: separate Upgrader and migrate usages

### DIFF
--- a/interop/server.go
+++ b/interop/server.go
@@ -100,11 +100,15 @@ func RunInteropServer() error {
 		},
 		QUICConfig: quicConf,
 	}
-	webtransport.ConfigureHTTP3Server(h3Server)
 	s := &webtransport.Server{
 		ApplicationProtocols: protocols,
 		H3:                   h3Server,
 		CheckOrigin:          func(*http.Request) bool { return true },
+	}
+	upgrader := webtransport.Upgrader{
+		ApplicationProtocols: s.ApplicationProtocols,
+		ReorderingTimeout:    s.ReorderingTimeout,
+		CheckOrigin:          s.CheckOrigin,
 	}
 	defer s.Close()
 
@@ -119,7 +123,7 @@ func RunInteropServer() error {
 	}
 	for _, ep := range endpoints {
 		handler := func(w http.ResponseWriter, r *http.Request) {
-			c, err := s.Upgrade(w, r)
+			c, err := upgrader.Upgrade(w, r)
 			if err != nil {
 				logger.Error("upgrading failed", "endpoint", ep, "err", err)
 				w.WriteHeader(500)

--- a/interop_chrome/main.go
+++ b/interop_chrome/main.go
@@ -51,13 +51,14 @@ func main() {
 			Addr:      "localhost:12345",
 			Handler:   wmux,
 		},
+	}
+	upgrader := webtransport.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },
 	}
-	webtransport.ConfigureHTTP3Server(s.H3)
 	defer s.Close()
 
 	wmux.HandleFunc("/unidirectional", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := s.Upgrade(w, r)
+		conn, err := upgrader.Upgrade(w, r)
 		if err != nil {
 			log.Printf("upgrading failed: %s", err)
 			w.WriteHeader(500)

--- a/server.go
+++ b/server.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
-	"slices"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -17,8 +15,6 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/dunglas/httpsfv"
 )
 
 const (
@@ -33,22 +29,33 @@ const (
 
 type quicConnKeyType struct{}
 
-var quicConnKey = quicConnKeyType{}
+var serverQUICConnKey = quicConnKeyType{}
 
-func ConfigureHTTP3Server(s *http3.Server) {
-	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64, 2)
+type serverQUICConn struct {
+	*quic.Conn
+	sessionManager *sessionManager
+}
+
+func (s *Server) configureHTTP3Server(h3 *http3.Server) {
+	if h3.AdditionalSettings == nil {
+		h3.AdditionalSettings = make(map[uint64]uint64, 2)
 	}
 	// send the old setting for backwards compatibility with older clients
-	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
-	s.AdditionalSettings[settingsWebTransportEnabled] = 1
-	s.EnableDatagrams = true
-	origConnContext := s.ConnContext
-	s.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {
+	h3.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
+	h3.AdditionalSettings[settingsWebTransportEnabled] = 1
+	h3.EnableDatagrams = true
+	origConnContext := h3.ConnContext
+	h3.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {
 		if origConnContext != nil {
 			ctx = origConnContext(ctx, conn)
 		}
-		ctx = context.WithValue(ctx, quicConnKey, conn)
+		s.connsMx.Lock()
+		sessManager := s.conns[conn]
+		s.connsMx.Unlock()
+		ctx = context.WithValue(ctx, serverQUICConnKey, &serverQUICConn{
+			Conn:           conn,
+			sessionManager: sessManager,
+		})
 		return ctx
 	}
 }
@@ -56,10 +63,12 @@ func ConfigureHTTP3Server(s *http3.Server) {
 type Server struct {
 	H3 *http3.Server
 
+	// Deprecated: use Upgrader.ApplicationProtocols instead.
 	// ApplicationProtocols is a list of application protocols that can be negotiated,
 	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-14 for details.
 	ApplicationProtocols []string
 
+	// Deprecated: use Upgrader.ReorderingTimeout instead.
 	// ReorderingTimeout is the maximum time an incoming WebTransport stream that cannot be associated
 	// with a session is buffered. It is also the maximum time a WebTransport connection request is
 	// blocked waiting for the client's SETTINGS are received.
@@ -68,6 +77,7 @@ type Server struct {
 	// Defaults to 5 seconds.
 	ReorderingTimeout time.Duration
 
+	// Deprecated: use Upgrader.CheckOrigin instead.
 	// CheckOrigin is used to validate the request origin, thereby preventing cross-site request forgery.
 	// CheckOrigin returns true if the request Origin header is acceptable.
 	// If unset, a safe default is used: If the Origin header is set, it is checked that it
@@ -101,9 +111,14 @@ func (s *Server) timeout() time.Duration {
 }
 
 func (s *Server) init() error {
-	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	if s.H3 == nil {
+		return errors.New("webtransport: H3 server is required")
+	}
 
 	s.conns = make(map[*quic.Conn]*sessionManager)
+	s.configureHTTP3Server(s.H3)
+
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 	if s.CheckOrigin == nil {
 		s.CheckOrigin = checkSameOrigin
 	}
@@ -319,95 +334,19 @@ func (s *Server) Close() error {
 	return err
 }
 
+// Upgrade upgrades an incoming HTTP request to a WebTransport session.
+//
+// Deprecated: use Upgrader.Upgrade instead.
 func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, error) {
 	if err := s.initialize(); err != nil {
 		return nil, err
 	}
-	if r.Method != http.MethodConnect {
-		return nil, fmt.Errorf("expected CONNECT request, got %s", r.Method)
+	u := &Upgrader{
+		ApplicationProtocols: s.ApplicationProtocols,
+		ReorderingTimeout:    s.ReorderingTimeout,
+		CheckOrigin:          s.CheckOrigin,
 	}
-	if r.Proto != protocolHeader {
-		return nil, fmt.Errorf("unexpected protocol: %s", r.Proto)
-	}
-	if !s.CheckOrigin(r) {
-		return nil, errors.New("webtransport: request origin not allowed")
-	}
-
-	id := r.Context().Value(quicConnKey)
-	if id == nil {
-		return nil, errors.New("webtransport: missing QUIC connection")
-	}
-	conn := id.(*quic.Conn)
-
-	selectedProtocol := s.selectProtocol(r.Header[http.CanonicalHeaderKey(wtAvailableProtocolsHeader)])
-
-	// Wait for SETTINGS
-	settingser := w.(http3.Settingser)
-	timer := time.NewTimer(s.timeout())
-	defer timer.Stop()
-	select {
-	case <-settingser.ReceivedSettings():
-	case <-timer.C:
-		return nil, errors.New("webtransport: didn't receive the client's SETTINGS on time")
-	}
-	settings := settingser.Settings()
-	if !settings.EnableDatagrams {
-		return nil, errors.New("webtransport: missing datagram support")
-	}
-
-	if selectedProtocol != "" {
-		v, err := httpsfv.Marshal(httpsfv.NewItem(selectedProtocol))
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal selected protocol: %w", err)
-		}
-		w.Header().Add(wtProtocolHeader, v)
-	}
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
-
-	str := w.(http3.HTTPStreamer).HTTPStream()
-	sessID := sessionID(str.StreamID())
-
-	// The session manager should already exist because ServeQUICConn creates it
-	// before any HTTP requests can be processed on this connection.
-	s.connsMx.Lock()
-	defer s.connsMx.Unlock()
-
-	sessMgr, ok := s.conns[conn]
-	if !ok {
-		return nil, errors.New("webtransport: connection session manager not found")
-	}
-
-	sess := newSession(context.WithoutCancel(r.Context()), sessID, conn, str, selectedProtocol)
-	sessMgr.AddSession(sessID, sess)
-	return sess, nil
-}
-
-func (s *Server) selectProtocol(theirs []string) string {
-	list, err := httpsfv.UnmarshalList(theirs)
-	if err != nil {
-		return ""
-	}
-	offered := make([]string, 0, len(list))
-	for _, item := range list {
-		i, ok := item.(httpsfv.Item)
-		if !ok {
-			return ""
-		}
-		protocol, ok := i.Value.(string)
-		if !ok {
-			return ""
-		}
-		offered = append(offered, protocol)
-	}
-	var selectedProtocol string
-	for _, p := range offered {
-		if slices.Contains(s.ApplicationProtocols, p) {
-			selectedProtocol = p
-			break
-		}
-	}
-	return selectedProtocol
+	return u.Upgrade(w, r)
 }
 
 // copied from https://github.com/gorilla/websocket

--- a/server_test.go
+++ b/server_test.go
@@ -31,17 +31,17 @@ func scaleDuration(d time.Duration) time.Duration {
 }
 
 func TestUpgradeFailures(t *testing.T) {
-	var s webtransport.Server
+	var u webtransport.Upgrader
 
 	t.Run("wrong request method", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/webtransport", nil)
-		_, err := s.Upgrade(httptest.NewRecorder(), req)
+		_, err := u.Upgrade(httptest.NewRecorder(), req)
 		require.EqualError(t, err, "expected CONNECT request, got GET")
 	})
 
 	t.Run("wrong protocol", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodConnect, "/webtransport", nil)
-		_, err := s.Upgrade(httptest.NewRecorder(), req)
+		_, err := u.Upgrade(httptest.NewRecorder(), req)
 		require.EqualError(t, err, "unexpected protocol: HTTP/1.1")
 	})
 }
@@ -75,7 +75,6 @@ func TestServerReorderedUpgradeRequest(t *testing.T) {
 	udpConn, err := net.ListenUDP("udp", nil)
 	require.NoError(t, err)
 	port := udpConn.LocalAddr().(*net.UDPAddr).Port
-	webtransport.ConfigureHTTP3Server(s.H3)
 	go s.Serve(udpConn)
 
 	cconn, err := quic.DialAddr(
@@ -138,7 +137,6 @@ func TestServerReorderedUpgradeRequestTimeout(t *testing.T) {
 	udpConn, err := net.ListenUDP("udp", nil)
 	require.NoError(t, err)
 	port := udpConn.LocalAddr().(*net.UDPAddr).Port
-	webtransport.ConfigureHTTP3Server(s.H3)
 	go s.Serve(udpConn)
 
 	cconn, err := quic.DialAddr(
@@ -197,9 +195,14 @@ func TestServerSettingsCheck(t *testing.T) {
 		ReorderingTimeout: timeout,
 	}
 	errChan := make(chan error, 1)
+	upgrader := webtransport.Upgrader{
+		ApplicationProtocols: s.ApplicationProtocols,
+		ReorderingTimeout:    s.ReorderingTimeout,
+		CheckOrigin:          s.CheckOrigin,
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
-		_, err := s.Upgrade(w, r)
+		_, err := upgrader.Upgrade(w, r)
 		w.WriteHeader(http.StatusNotImplemented)
 		errChan <- err
 	})
@@ -207,7 +210,6 @@ func TestServerSettingsCheck(t *testing.T) {
 	udpConn, err := net.ListenUDP("udp", nil)
 	require.NoError(t, err)
 	port := udpConn.LocalAddr().(*net.UDPAddr).Port
-	webtransport.ConfigureHTTP3Server(s.H3)
 	go s.Serve(udpConn)
 
 	cconn, err := quic.DialAddr(

--- a/upgrader.go
+++ b/upgrader.go
@@ -1,0 +1,140 @@
+package webtransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/dunglas/httpsfv"
+)
+
+// Upgrader upgrades incoming HTTP requests to WebTransport sessions.
+//
+// It is safe to call Upgrader methods concurrently.
+type Upgrader struct {
+	// ApplicationProtocols is a list of application protocols that can be negotiated,
+	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-14 for details.
+	ApplicationProtocols []string
+
+	// ReorderingTimeout is the maximum time a WebTransport connection request is
+	// blocked waiting for the client's SETTINGS to be received.
+	// Defaults to 5 seconds.
+	ReorderingTimeout time.Duration
+
+	// CheckOrigin is used to validate the request origin, thereby preventing cross-site request forgery.
+	// CheckOrigin returns true if the request Origin header is acceptable.
+	// If unset, a safe default is used: If the Origin header is set, it is checked that it
+	// matches the request's Host header.
+	CheckOrigin func(r *http.Request) bool
+}
+
+func (u *Upgrader) timeout() time.Duration {
+	timeout := u.ReorderingTimeout
+	if timeout == 0 {
+		return 5 * time.Second
+	}
+	return timeout
+}
+
+func (u *Upgrader) selectProtocol(theirs []string) string {
+	list, err := httpsfv.UnmarshalList(theirs)
+	if err != nil {
+		return ""
+	}
+	offered := make([]string, 0, len(list))
+	for _, item := range list {
+		i, ok := item.(httpsfv.Item)
+		if !ok {
+			return ""
+		}
+		protocol, ok := i.Value.(string)
+		if !ok {
+			return ""
+		}
+		offered = append(offered, protocol)
+	}
+	var selectedProtocol string
+	for _, p := range offered {
+		if slices.Contains(u.ApplicationProtocols, p) {
+			selectedProtocol = p
+			break
+		}
+	}
+	return selectedProtocol
+}
+
+// Upgrade upgrades an incoming HTTP request to a WebTransport session.
+func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, error) {
+	if r.Method != http.MethodConnect {
+		return nil, fmt.Errorf("expected CONNECT request, got %s", r.Method)
+	}
+	if r.Proto != protocolHeader {
+		return nil, fmt.Errorf("unexpected protocol: %s", r.Proto)
+	}
+	checkOrigin := u.CheckOrigin
+	if checkOrigin == nil {
+		checkOrigin = checkSameOrigin
+	}
+	if !checkOrigin(r) {
+		return nil, errors.New("webtransport: request origin not allowed")
+	}
+
+	v := r.Context().Value(serverQUICConnKey)
+	conn, ok := v.(*serverQUICConn)
+	if !ok || conn == nil || conn.Conn == nil {
+		return nil, errors.New("webtransport: missing QUIC connection")
+	}
+
+	selectedProtocol := u.selectProtocol(r.Header[http.CanonicalHeaderKey(wtAvailableProtocolsHeader)])
+
+	settingser, ok := w.(http3.Settingser)
+	if !ok {
+		return nil, errors.New("webtransport: response writer doesn't implement http3.Settingser")
+	}
+	timer := time.NewTimer(u.timeout())
+	defer timer.Stop()
+	select {
+	case <-settingser.ReceivedSettings():
+	case <-timer.C:
+		return nil, errors.New("webtransport: didn't receive the client's SETTINGS on time")
+	}
+	settings := settingser.Settings()
+	if !settings.EnableDatagrams {
+		return nil, errors.New("webtransport: missing datagram support")
+	}
+
+	if selectedProtocol != "" {
+		v, err := httpsfv.Marshal(httpsfv.NewItem(selectedProtocol))
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal selected protocol: %w", err)
+		}
+		w.Header().Add(wtProtocolHeader, v)
+	}
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, errors.New("webtransport: response writer doesn't implement http.Flusher")
+	}
+	flusher.Flush()
+
+	httpStreamer, ok := w.(http3.HTTPStreamer)
+	if !ok {
+		return nil, errors.New("webtransport: response writer doesn't implement http3.HTTPStreamer")
+	}
+	str := httpStreamer.HTTPStream()
+	sessID := sessionID(str.StreamID())
+
+	if conn.sessionManager == nil {
+		return nil, errors.New("webtransport: session manager resolver unavailable")
+	}
+
+	sess := newSession(context.WithoutCancel(r.Context()), sessID, conn.Conn, str, selectedProtocol)
+	conn.sessionManager.AddSession(sessID, sess)
+	return sess, nil
+}

--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -31,7 +31,6 @@ func runServer(t *testing.T, s *webtransport.Server) (addr *net.UDPAddr, close f
 	udpConn, err := net.ListenUDP("udp", laddr)
 	require.NoError(t, err)
 
-	webtransport.ConfigureHTTP3Server(s.H3)
 	servErr := make(chan error, 1)
 	go func() {
 		servErr <- s.Serve(udpConn)
@@ -97,9 +96,14 @@ func sendDataAndCheckEcho(t *testing.T, sess *webtransport.Session) {
 
 func addHandler(t *testing.T, s *webtransport.Server, connHandler func(*webtransport.Session)) {
 	t.Helper()
+	upgrader := webtransport.Upgrader{
+		ApplicationProtocols: s.ApplicationProtocols,
+		ReorderingTimeout:    s.ReorderingTimeout,
+		CheckOrigin:          s.CheckOrigin,
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := s.Upgrade(w, r)
+		conn, err := upgrader.Upgrade(w, r)
 		if err != nil {
 			t.Logf("upgrading failed: %s", err)
 			w.WriteHeader(404) // TODO: better error code
@@ -146,6 +150,42 @@ func TestApplicationProtocolNegotiation(t *testing.T) {
 	t.Run("no server protocols", func(t *testing.T) {
 		testApplicationProtocolNegotiation(t, []string{"foo", "bar"}, []string{}, "")
 	})
+}
+
+func TestUpgraderIntegration(t *testing.T) {
+	s := &webtransport.Server{
+		H3: &http3.Server{
+			TLSConfig: webtransport.TLSConf,
+			QUICConfig: &quic.Config{
+				EnableDatagrams:                  true,
+				EnableStreamResetPartialDelivery: true,
+				Tracer:                           qlog.DefaultConnectionTracer,
+			},
+		},
+	}
+	defer s.Close()
+	addHandler(t, s, newEchoHandler(t))
+
+	addr, closeServer := runServer(t, s)
+	defer closeServer()
+
+	d := webtransport.Dialer{
+		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+			Tracer:                           qlog.DefaultConnectionTracer,
+		},
+	}
+	defer d.Close()
+
+	url := fmt.Sprintf("https://localhost:%d/webtransport", addr.Port)
+	rsp, sess, err := d.Dial(context.Background(), url, nil)
+	require.NoError(t, err)
+	defer sess.CloseWithError(0, "")
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+
+	sendDataAndCheckEcho(t, sess)
 }
 
 func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverProtocols []string, expected string) {
@@ -708,11 +748,16 @@ func TestSessionContextValues(t *testing.T) {
 		},
 	}
 	mux := http.NewServeMux()
+	upgrader := webtransport.Upgrader{
+		ApplicationProtocols: s.ApplicationProtocols,
+		ReorderingTimeout:    s.ReorderingTimeout,
+		CheckOrigin:          s.CheckOrigin,
+	}
 	serverSessChan := make(chan *webtransport.Session, 1)
 	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), contextKey, serverValue)
 		r = r.WithContext(ctx)
-		conn, err := s.Upgrade(w, r)
+		conn, err := upgrader.Upgrade(w, r)
 		if err != nil {
 			t.Logf("upgrading failed: %s", err)
 			w.WriteHeader(404)


### PR DESCRIPTION
## Summary
This PR separates upgrade handling from `Server` into `Upgrader`, and updates usages in tests and interop to call `Upgrader` directly.

## Motivation
I wanted to make the API boundary clearer by keeping transport lifecycle in `Server` and handshake/session-upgrade logic in `Upgrader`.

## Changes
- Move `Upgrader` implementation into `upgrader.go`.
- Keep `Server.Upgrade` as a deprecated compatibility shim.
- Keep HTTP/3 configuration internal to `Server`.
- Use per-connection context state (`serverQUICConn`) for upgrade.
- Migrate remaining call sites from `server.Upgrade(...)` to `upgrader.Upgrade(...)` (tests + interop).

## Compatibility
- No intended behavior change.
- `Server.Upgrade` is still available for gradual migration.

## Validation
- `go test ./...`

If you prefer, I can further split this into smaller PRs.
