### PR TITLE
send WebTransport SETTINGS expected by Safari 26.4

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -1,11 +1,25 @@
 package webtransport
 
-// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
-// that was used up until draft-ietf-webtrans-http3-06.
-const settingsEnableWebtransportDraft06 = 0x2b603742
+const (
+	// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
+	// that was used up until draft-ietf-webtrans-http3-06.
+	settingsEnableWebtransportDraft06 = 0x2b603742
 
-// settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
-const settingsWebTransportEnabled = 0x2c7cf000
+	// settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
+	settingsWebTransportEnabled = 0x2c7cf000
+
+	// settingsWebTransportMaxSessions is the value for SETTINGS_WT_MAX_SESSIONS
+	settingsWebTransportMaxSessions = 0x14e9cd29
+
+	// settingsWebTransportInitialMaxStreamsUni is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_UNI
+	settingsWebTransportInitialMaxStreamsUni = 0x2b64
+
+	// settingsWebTransportInitialMaxStreamsBidi is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI
+	settingsWebTransportInitialMaxStreamsBidi = 0x2b65
+
+	// settingsWebTransportInitialMaxData is the value for SETTINGS_WT_INITIAL_MAX_DATA
+	settingsWebTransportInitialMaxData = 0x2b61
+)
 
 const (
 	// protocolHeader is the Extended-CONNECT :protocol value per

--- a/protocol.go
+++ b/protocol.go
@@ -7,4 +7,16 @@ const settingsEnableWebtransportDraft06 = 0x2b603742
 // settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
 const settingsWebTransportEnabled = 0x2c7cf000
 
+// settingsWebTransportMaxSessions is the value for SETTINGS_WT_MAX_SESSIONS
+const settingsWebTransportMaxSessions = 0x14e9cd29
+
+// settingsWebTransportInitialMaxStreamsUni is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_UNI
+const settingsWebTransportInitialMaxStreamsUni = 0x2b64
+
+// settingsWebTransportInitialMaxStreamsBidi is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI
+const settingsWebTransportInitialMaxStreamsBidi = 0x2b65
+
+// settingsWebTransportInitialMaxData is the value for SETTINGS_WT_INITIAL_MAX_DATA
+const settingsWebTransportInitialMaxData = 0x2b61
+
 const protocolHeader = "webtransport"

--- a/server.go
+++ b/server.go
@@ -37,11 +37,20 @@ var quicConnKey = quicConnKeyType{}
 
 func ConfigureHTTP3Server(s *http3.Server) {
 	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64, 2)
+		s.AdditionalSettings = make(map[uint64]uint64)
 	}
 	// send the old setting for backwards compatibility with older clients
 	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
 	s.AdditionalSettings[settingsWebTransportEnabled] = 1
+
+	// Safari requires SETTINGS_WT_MAX_SESSIONS >= 1 (draft-ietf-webtrans-http3-14)
+	s.AdditionalSettings[settingsWebTransportMaxSessions] = 1<<62 - 1
+
+	// Required when SETTINGS_WT_MAX_SESSIONS > 1
+	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsUni] = 1 << 60
+	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsBidi] = 1 << 60
+	s.AdditionalSettings[settingsWebTransportInitialMaxData] = 1 << 60
+
 	s.EnableDatagrams = true
 	origConnContext := s.ConnContext
 	s.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ var quicConnKey = quicConnKeyType{}
 
 func ConfigureHTTP3Server(s *http3.Server) {
 	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64)
+		s.AdditionalSettings = make(map[uint64]uint64, 6)
 	}
 	// send the old setting for backwards compatibility with older clients
 	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1


### PR DESCRIPTION
Safari 26.4 requires SETTINGS_WT_MAX_SESSIONS to be present and >= 1 for WebTransport sessions to be established.

When MAX_SESSIONS > 1, the draft also requires advertising the associated
flow control settings: WT_INITIAL_MAX_STREAMS_UNI, WT_INITIAL_MAX_STREAMS_BIDI,
and WT_INITIAL_MAX_DATA.

All values are set to their practical maximums (QUIC varint limit) to avoid
artificially constraining clients.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Safari 26.4 WebTransport SETTINGS for max sessions and flow control
> - Adds four new SETTINGS constants to [protocol.go](https://github.com/quic-go/webtransport-go/pull/261/files#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38): `settingsWebTransportMaxSessions`, `settingsWebTransportInitialMaxStreamsUni`, `settingsWebTransportInitialMaxStreamsBidi`, and `settingsWebTransportInitialMaxData`.
> - Updates `ConfigureHTTP3Server` in [server.go](https://github.com/quic-go/webtransport-go/pull/261/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6) to advertise these settings with large permissive values (`(1<<62)-1` for max sessions, `1<<60` for stream/data limits).
> - Behavioral Change: Servers configured via `ConfigureHTTP3Server` now send additional SETTINGS frames on connect, which Safari 26.4 requires for WebTransport to function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 982a78c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->