### PR TITLE
fix stream close race condition on session close

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -74,12 +74,12 @@ func newSendStream(str quicSendStream, hdr []byte, onClose func()) *SendStream {
 // If the stream was canceled, the error is a [StreamError].
 func (s *SendStream) Write(b []byte) (int, error) {
 	n, err := s.write(b)
-	if err != nil && !isTimeoutError(err) {
-		s.onClose()
-	}
 	var strErr *quic.StreamError
 	if errors.As(err, &strErr) && strErr.ErrorCode == WTSessionGoneErrorCode {
-		return n, s.handleSessionGoneError()
+		err = s.handleSessionGoneError()
+	}
+	if err != nil && !isTimeoutError(err) {
+		s.onClose()
 	}
 	return n, maybeConvertStreamError(err)
 }
@@ -277,12 +277,12 @@ func newReceiveStream(str quicReceiveStream, onClose func()) *ReceiveStream {
 // If the stream was canceled, the error is a [StreamError].
 func (s *ReceiveStream) Read(b []byte) (int, error) {
 	n, err := s.str.Read(b)
-	if err != nil && !isTimeoutError(err) {
-		s.onClose()
-	}
 	var strErr *quic.StreamError
 	if errors.As(err, &strErr) && strErr.ErrorCode == WTSessionGoneErrorCode {
-		return n, s.handleSessionGoneError()
+		err = s.handleSessionGoneError()
+	}
+	if err != nil && !isTimeoutError(err) {
+		s.onClose()
 	}
 	return n, maybeConvertStreamError(err)
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -227,14 +227,13 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	case <-time.After(scaleDuration(10 * time.Millisecond)):
 	}
 
-	// call CloseSession()
 	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
 	sm.CloseSession(sessionErr)
 
 	select {
 	case err := <-errChan:
 		require.ErrorIs(t, err, sessionErr)
-	case <-time.After(scaleDuration(1 * time.Second)):
+	case <-time.After(scaleDuration(time.Second)):
 		t.Fatal("Read() should not hang after CloseSession()")
 	}
 }
@@ -357,14 +356,13 @@ func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	case <-time.After(scaleDuration(10 * time.Millisecond)):
 	}
 
-	// call CloseSession()
 	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
 	sm.CloseSession(sessionErr)
 
 	select {
 	case err := <-errChan:
 		require.ErrorIs(t, err, sessionErr)
-	case <-time.After(scaleDuration(1 * time.Second)):
+	case <-time.After(scaleDuration(time.Second)):
 		t.Fatal("Write() should not hang after CloseSession()")
 	}
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -203,6 +203,42 @@ func TestReceiveStreamSessionGone(t *testing.T) {
 	}
 }
 
+func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
+	sendStr, recvStr := newUniStreamPair(t)
+
+	sm := newStreamsMap()
+	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) })
+	sm.AddStream(recvStr.StreamID(), str.closeWithSession)
+
+	// start reading
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := str.Read(make([]byte, 100))
+		errChan <- err
+	}()
+
+	// the remote peer sends a WT_SESSION_GONE
+	sendStr.CancelWrite(WTSessionGoneErrorCode)
+
+	// Read() should block, waiting for CloseSession()
+	select {
+	case <-errChan:
+		t.Fatal("should not happen")
+	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	}
+
+	// call CloseSession()
+	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
+	sm.CloseSession(sessionErr)
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, sessionErr)
+	case <-time.After(scaleDuration(1 * time.Second)):
+		t.Fatal("Read() should not hang after CloseSession()")
+	}
+}
+
 func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
@@ -290,6 +326,47 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 	data, err := io.ReadAll(serverStr)
 	require.NoError(t, err)
 	require.Equal(t, append(hdr, []byte("data")...), data)
+}
+
+func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
+	sendStr, recvStr := newUniStreamPair(t)
+
+	sm := newStreamsMap()
+	str := newSendStream(sendStr, nil, func() { sm.RemoveStream(sendStr.StreamID()) })
+	sm.AddStream(sendStr.StreamID(), str.closeWithSession)
+
+	// write in a loop
+	errChan := make(chan error, 1)
+	go func() {
+		for {
+			if _, err := str.Write([]byte("foo")); err != nil {
+				errChan <- err
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// the remote peer sends a WT_SESSION_GONE
+	recvStr.CancelRead(WTSessionGoneErrorCode)
+
+	// Write() should block, waiting for closeWithSession()
+	select {
+	case <-errChan:
+		t.Fatal("should not happen")
+	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	}
+
+	// call CloseSession()
+	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
+	sm.CloseSession(sessionErr)
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, sessionErr)
+	case <-time.After(scaleDuration(1 * time.Second)):
+		t.Fatal("Write() should not hang after CloseSession()")
+	}
 }
 
 func TestReceiveStreamClose(t *testing.T) {


### PR DESCRIPTION
Both ReceiveStream.Read() and SendStream.Write() can freeze due a race condition that is triggered when the session is concurrently closed on the local side and the remote side:

* Read() / Write() is called

* the remote peer sends a RESET_STREAM frame with the WT_SESSION_GONE code.

* The error is detected by Read() / Write(), that calls onClose, that removes the stream from the stream map inside  the local session. The WT_SESSION_GONE code also makes it wait for the "closed" signal from the local session

* the local session is concurrently closed with SessionClose(). The "closed" signal is sent to any open stream except the one waiting for it, because it is not part of the stream map anymore

* The stream freezes, waiting forever for closed

This PR fixes the issue by moving the removal of the stream from the map after the reception of the "closed" signal.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stream freezing race condition in `SendStream.Write` and `ReceiveStream.Read`
> Previously, `Write` and `Read` returned immediately on `WTSessionGoneErrorCode`, causing a race where the stream could freeze if the session hadn't fully closed yet.
>
> - Both methods now assign the result of `handleSessionGoneError()` to `err` and wait for it to complete before returning, ensuring the session is fully closed
> - `onClose()` is moved to execute after session-gone handling, and only for non-timeout errors
> - New tests cover the freeze scenario: trigger `WTSessionGoneErrorCode`, assert blocking, close the session, assert unblocking with the correct `SessionError`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4a708a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->