### PR TITLE
ci: pin non-GitHub-owned GitHub Actions

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           platforms: linux/amd64,linux/arm64
       - name: Login to Docker Hub
         if: github.event_name == 'push'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -37,11 +37,11 @@ jobs:
         # but they can be useful when debugging regressions.
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
+            echo "tag=${GITHUB_REF#refs/tags/}" | tee -a "$GITHUB_OUTPUT";
           else
-            echo 'tag=latest' | tee -a $GITHUB_OUTPUT;
+            echo 'tag=latest' | tee -a "$GITHUB_OUTPUT";
           fi
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: "."
           file: "interop/Dockerfile"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -12,7 +12,7 @@ jobs:
         go: [ "1.25.x", "1.26.x" ]
     steps:
     - uses: actions/checkout@v6
-    - uses: nanasess/setup-chromedriver@v3
+    - uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c # v3.0.0
       with:
         chromedriver-version: '142.0.7444.162'
     - uses: actions/setup-go@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         run: go mod tidy -diff
       - name: golangci-lint
         if: success() || failure() # run this step even if the previous one failed
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           args: --timeout=3m
           version: v2.9.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,7 @@ jobs:
           TIMESCALE_FACTOR: 10
         run: go test -v -cover -coverprofile coverage.txt ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out report.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           OS: ${{ matrix.os }}
           GO: ${{ matrix.go }}
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test report to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           OS: ${{ matrix.os }}
           GO: ${{ matrix.go }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Pin non-GitHub-owned Actions to specific commit SHAs in CI workflows
Replaces floating version tags with pinned commit SHAs for third-party Actions across all CI workflows. Affected actions include `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`, `nanasess/setup-chromedriver`, `golangci/golangci-lint-action`, and `codecov/codecov-action`. Also quotes the `GITHUB_OUTPUT` path in two `echo` steps in [build-interop-docker.yml](.github/workflows/build-interop-docker.yml).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ade87f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->