### PR TITLE
send SETTINGS_WT_ENABLED from the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,10 +119,6 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
 	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
 	// for its supported draft version, so the server can negotiate the version.
-	// Advertise the current codepoint by default; callers can advertise older
-	// draft codepoints too via AdditionalSettings (Section 7.1: an endpoint
-	// supporting multiple versions sends a value for each) — e.g. the legacy
-	// SETTINGS_WEBTRANSPORT_MAX_SESSIONS that some deployed servers still use.
 	versionSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
 	tr := &http3.Transport{
 		EnableDatagrams:    true,

--- a/client.go
+++ b/client.go
@@ -119,10 +119,9 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
 	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
 	// for its supported draft version, so the server can negotiate the version.
-	versionSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
 	tr := &http3.Transport{
 		EnableDatagrams:    true,
-		AdditionalSettings: versionSettings,
+		AdditionalSettings: map[uint64]uint64{settingsWebTransportEnabled: 1},
 	}
 	rsp, sess, err := d.handleConn(ctx, tr, qconn, req)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -116,7 +116,18 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 		return nil, nil, err
 	}
 
-	tr := &http3.Transport{EnableDatagrams: true}
+	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
+	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
+	// for its supported draft version, so the server can negotiate the version.
+	// Advertise the current codepoint by default; callers can advertise older
+	// draft codepoints too via AdditionalSettings (Section 7.1: an endpoint
+	// supporting multiple versions sends a value for each) — e.g. the legacy
+	// SETTINGS_WEBTRANSPORT_MAX_SESSIONS that some deployed servers still use.
+	versionSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
+	tr := &http3.Transport{
+		EnableDatagrams:    true,
+		AdditionalSettings: versionSettings,
+	}
 	rsp, sess, err := d.handleConn(ctx, tr, qconn, req)
 	if err != nil {
 		var msg string


### PR DESCRIPTION
draft-ietf-webtrans-http3-15 negotiates the draft version via the SETTINGS_WT_ENABLED codepoint (sections 3.1 and 7.1): for draft versions both client and server MUST send it. 

The Dialer previously advertised no WebTransport setting client-side, so servers that gate WebTransport on the client's advertised support/version rejected the session.

Send settingsWebTransportEnabled=1 by default and add Dialer.AdditionalSettings, merged on top (last wins) so callers can advertise older draft codepoints that some deployed servers still require, or override the default

Solves: #269 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send `SETTINGS_WT_ENABLED` from the HTTP/3 transport client
> Adds `settingsWebTransportEnabled=1` to the `AdditionalSettings` map on the `http3.Transport` in `Dialer.Dial`, as required by the WebTransport draft spec. Previously this setting was not sent by the client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f52009.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->