### PR TITLE
close UDP socket created by Server.ListenAndServe

### DIFF
--- a/server.go
+++ b/server.go
@@ -114,6 +114,14 @@ func (s *Server) Serve(conn net.PacketConn) error {
 	if err := s.initialize(); err != nil {
 		return err
 	}
+
+	s.refCount.Add(1)
+	defer s.refCount.Done()
+
+	return s.serve(conn)
+}
+
+func (s *Server) serve(conn net.PacketConn) error {
 	var quicConf *quic.Config
 	if s.H3.QUICConfig != nil {
 		quicConf = s.H3.QUICConfig.Clone()
@@ -269,6 +277,12 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 }
 
 func (s *Server) ListenAndServe() error {
+	if err := s.initialize(); err != nil {
+		return err
+	}
+	s.refCount.Add(1)
+	defer s.refCount.Done()
+
 	addr := s.H3.Addr
 	if addr == "" {
 		addr = ":https"
@@ -281,7 +295,9 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	return s.Serve(conn)
+	defer conn.Close()
+
+	return s.serve(conn)
 }
 
 func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {

--- a/server_test.go
+++ b/server_test.go
@@ -297,3 +297,49 @@ func TestServerConnectionStateChecks(t *testing.T) {
 		})
 	}
 }
+
+func TestListenAndServeCloseClosesUDPConn(t *testing.T) {
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	udpAddr := udpConn.LocalAddr().(*net.UDPAddr)
+	addr := udpAddr.String()
+	require.NoError(t, udpConn.Close())
+
+	s := webtransport.Server{H3: &http3.Server{Addr: addr, TLSConfig: webtransport.TLSConf}}
+	webtransport.ConfigureHTTP3Server(s.H3)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- s.ListenAndServe() }()
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(100*time.Millisecond))
+		defer cancel()
+		conn, err := quic.DialAddr(
+			ctx,
+			addr,
+			&tls.Config{
+				RootCAs:    webtransport.CertPool,
+				ServerName: "localhost",
+				NextProtos: []string{http3.NextProtoH3},
+			},
+			&quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+		)
+		if err != nil {
+			return false
+		}
+		conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "")
+		return true
+	}, scaleDuration(5*time.Second), scaleDuration(20*time.Millisecond))
+
+	require.NoError(t, s.Close())
+
+	again, err := net.ListenUDP("udp", udpAddr)
+	require.NoError(t, err)
+	require.NoError(t, again.Close())
+
+	select {
+	case <-serveErr:
+	case <-time.After(time.Second):
+		t.Fatal("ListenAndServe did not return after Close")
+	}
+}


### PR DESCRIPTION
Fixes #272.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close UDP socket created by `Server.ListenAndServe` on server shutdown
> Previously, `ListenAndServe` delegated to `Serve` after creating a UDP socket, but never closed that socket when the server shut down. This PR fixes the leak by deferring `conn.Close()` in `ListenAndServe` and extracting shared serving logic into a new `serve` helper used by both `Serve` and `ListenAndServe`.
>
> - `Server.ListenAndServe` now calls `s.initialize()` directly, increments `refCount`, defers `conn.Close()`, and calls the new `serve` helper
> - `Server.Serve` delegates its logic to the same `serve` helper with equivalent behavior and its own `refCount` tracking
> - A new test (`TestListenAndServeCloseClosesUDPConn`) verifies the UDP port can be rebound after `Close()` is called
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acbf5c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->