### PR TITLE
run go fix across the entire codebase

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestErrorCodeRoundTrip(t *testing.T) {
-	for i := 0; i < 1e4; i++ {
+	for range int(1e4) {
 		n := StreamErrorCode(rand.Int64())
 		httpCode := webtransportCodeToHTTPCode(n)
 		errorCode, err := httpCodeToWebtransportCode(httpCode)
@@ -39,7 +39,7 @@ func TestErrorCodeConversionErrors(t *testing.T) {
 
 	t.Run("greased value", func(t *testing.T) {
 		var counter int
-		for i := 0; i < 1e4; i++ {
+		for range int(1e4) {
 			c := firstErrorCode + uint64(rand.Uint32())
 			if (c-0x21)%0x1f != 0 {
 				continue

--- a/interop/server.go
+++ b/interop/server.go
@@ -36,13 +36,13 @@ func parseServerRequests(s string) map[string][]string {
 		if pathStr == "" {
 			continue
 		}
-		idx := strings.Index(pathStr, "/")
-		if idx < 0 {
+		before, after, ok := strings.Cut(pathStr, "/")
+		if !ok {
 			requests[pathStr] = []string{}
 			continue
 		}
-		endpoint := pathStr[:idx]
-		rest := pathStr[idx+1:]
+		endpoint := before
+		rest := after
 		requests[endpoint] = append(requests[endpoint], rest)
 	}
 	return requests

--- a/interop_chrome/main.go
+++ b/interop_chrome/main.go
@@ -83,7 +83,7 @@ func runHTTPServer(certHash [32]byte) {
 }
 
 func runUnidirectionalTest(sess *webtransport.Session) {
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 

--- a/server.go
+++ b/server.go
@@ -133,14 +133,11 @@ func (s *Server) Serve(conn net.PacketConn) error {
 		if err != nil {
 			return err
 		}
-		s.refCount.Add(1)
-		go func() {
-			defer s.refCount.Done()
-
+		s.refCount.Go(func() {
 			if err := s.ServeQUICConn(qconn); err != nil {
 				log.Printf("http3: error serving QUIC connection: %v", err)
 			}
-		}()
+		})
 	}
 }
 
@@ -199,10 +196,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 				return
 			}
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
+			wg.Go(func() {
 				typ, err := quicvarint.Peek(str)
 				if err != nil {
 					return
@@ -223,7 +217,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					return
 				}
 				sessMgr.AddStream(str, sessionID(id))
-			}()
+			})
 		}
 	}()
 
@@ -236,10 +230,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 				return
 			}
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
+			wg.Go(func() {
 				typ, err := quicvarint.Peek(str)
 				if err != nil {
 					return
@@ -260,7 +251,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					return
 				}
 				sessMgr.AddUniStream(str, sessionID(id))
-			}()
+			})
 		}
 	}()
 

--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -340,7 +340,7 @@ func TestMultipleClients(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(numClients)
-	for i := 0; i < numClients; i++ {
+	for range numClients {
 		go func() {
 			defer wg.Done()
 			d := webtransport.Dialer{
@@ -669,7 +669,7 @@ func TestDatagrams(t *testing.T) {
 
 	errChan := make(chan error, 1)
 
-	for i := 0; i < num; i++ {
+	for range num {
 		b := make([]byte, 800)
 		rand.Read(b)
 		mx.Lock()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Apply `go fix` modernizations across the codebase
- Replaces counted `for` loops with Go 1.22 integer range loops (`for range n`) in [errors_test.go](https://github.com/quic-go/webtransport-go/pull/275/files#diff-5c4d3e0fb6348a54d285f0812da0b323800e6e8c5d30b93e92a40677a267810f), [webtransport_test.go](https://github.com/quic-go/webtransport-go/pull/275/files#diff-db367bcaf9b172479f3cd9d9e7cbb5ca395e4d86b695f83d29e634b1e90328c0), and [interop_chrome/main.go](https://github.com/quic-go/webtransport-go/pull/275/files#diff-ec393d929a5caf3cd0ed0b923a9ba36204e2688dd8f47f38cf473673435df21c)
- Replaces manual `wg.Add(1)` + goroutine + `defer wg.Done()` patterns with `wg.Go(...)` calls in [server.go](https://github.com/quic-go/webtransport-go/pull/275/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6), including both stream-accept loops in `Server.ServeQUICConn` and connection tracking in `Server.Serve`
- Replaces manual `strings.Index` + slicing with `strings.Cut` in [interop/server.go](https://github.com/quic-go/webtransport-go/pull/275/files#diff-4640e6edb7a2c0a172bce99c08c1342b11b39d0f6586e7e422851c9b38279ae1)

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f4d225.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->