### PR TITLE
ci: run go fix as part of the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Check that go.mod is tidied
         if: success() || failure() # run this step even if the previous one failed
         run: go mod tidy -diff
+      - name: Run go fix
+        if: (success() || failure()) && matrix.go == '1.26.x'
+        run: go fix -diff ./...
       - name: golangci-lint
         if: success() || failure() # run this step even if the previous one failed
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `go fix -diff` check to the lint CI workflow
Adds a new step to [lint.yml](.github/workflows/lint.yml) that runs `go fix -diff ./...` for the Go 1.26.x matrix entry. The step runs even if prior steps fail, so `go fix` regressions are always surfaced.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e73cd61.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->