### PR TITLE
add support for the WT_ALPN_ERROR

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,7 +27,7 @@ type Dialer struct {
 	QUICConfig *quic.Config
 
 	// ApplicationProtocols is a list of application protocols that can be negotiated,
-	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-14 for details.
+	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15 for details.
 	ApplicationProtocols []string
 
 	// StreamReorderingTime is the time an incoming WebTransport stream that cannot be associated
@@ -252,29 +252,37 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
 		return rsp, nil, fmt.Errorf("received status %d", rsp.StatusCode)
 	}
-	var protocol string
-	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
-		protocol = d.negotiateProtocol(protocolHeader)
-	}
 	sessID := sessionID(requestStr.StreamID())
+	var protocol string
+	// Don't send WT_ALPN_ERROR if WT-Protocol is absent: the server didn't
+	// negotiate a protocol. Send it only when WT-Protocol is present but invalid.
+	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
+		var err error
+		protocol, err = d.negotiateProtocol(protocolHeader)
+		if err != nil {
+			sessErr := &SessionError{ErrorCode: WTALPNErrorCode, Message: err.Error()}
+			_ = closeSessionStream(requestStr, sessErr.ErrorCode, sessErr.Message)
+			return rsp, nil, sessErr
+		}
+	}
 	sess := newSession(context.WithoutCancel(ctx), sessID, qconn, requestStr, protocol)
 	sessMgr.AddSession(sessID, sess)
 	return rsp, sess, nil
 }
 
-func (d *Dialer) negotiateProtocol(theirs []string) string {
+func (d *Dialer) negotiateProtocol(theirs []string) (string, error) {
 	negotiatedProtocolItem, err := httpsfv.UnmarshalItem(theirs)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("webtransport: invalid WT-Protocol header: %w", err)
 	}
 	negotiatedProtocol, ok := negotiatedProtocolItem.Value.(string)
 	if !ok {
-		return ""
+		return "", errors.New("webtransport: invalid WT-Protocol header: value is not a string")
 	}
 	if !slices.Contains(d.ApplicationProtocols, negotiatedProtocol) {
-		return ""
+		return "", fmt.Errorf("webtransport: server selected application protocol %q that wasn't offered", negotiatedProtocol)
 	}
-	return negotiatedProtocol
+	return negotiatedProtocol, nil
 }
 
 func (d *Dialer) Close() error {

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,9 @@ const (
 	// WTRequirementsNotMetErrorCode is the error code of the
 	// WT_REQUIREMENTS_NOT_MET error.
 	WTRequirementsNotMetErrorCode quic.ApplicationErrorCode = 0x212c0d48
+
+	// WTALPNErrorCode is the error code of the WT_ALPN_ERROR error.
+	WTALPNErrorCode SessionErrorCode = 0x0817b3dd
 )
 
 // StreamError is the error that is returned from stream operations (Read, Write) when the stream is canceled.

--- a/server.go
+++ b/server.go
@@ -57,7 +57,7 @@ type Server struct {
 	H3 *http3.Server
 
 	// ApplicationProtocols is a list of application protocols that can be negotiated,
-	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-14 for details.
+	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15 for details.
 	ApplicationProtocols []string
 
 	// ReorderingTimeout is the maximum time an incoming WebTransport stream that cannot be associated

--- a/session.go
+++ b/session.go
@@ -398,6 +398,12 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 		return err
 	}
 
+	err = closeSessionStream(s.str, code, msg)
+	<-s.ctx.Done()
+	return err
+}
+
+func closeSessionStream(str http3Stream, code SessionErrorCode, msg string) error {
 	// truncate the message if it's too long
 	if len(msg) > maxCloseCapsuleErrorMsgLen {
 		msg = truncateUTF8(msg, maxCloseCapsuleErrorMsgLen)
@@ -410,15 +416,13 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 	// Optimistically send the WT_CLOSE_SESSION Capsule:
 	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
 	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
-	s.str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
-	if err := http3.WriteCapsule(quicvarint.NewWriter(s.str), closeSessionCapsuleType, b); err != nil {
-		s.str.CancelWrite(WTSessionGoneErrorCode)
+	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
+	if err := http3.WriteCapsule(quicvarint.NewWriter(str), closeSessionCapsuleType, b); err != nil {
+		str.CancelWrite(WTSessionGoneErrorCode)
 	}
 
-	s.str.CancelRead(WTSessionGoneErrorCode)
-	err = s.str.Close()
-	<-s.ctx.Done()
-	return err
+	str.CancelRead(WTSessionGoneErrorCode)
+	return str.Close()
 }
 
 func (s *Session) SendDatagram(b []byte) error {

--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -148,6 +148,70 @@ func TestApplicationProtocolNegotiation(t *testing.T) {
 	})
 }
 
+func TestApplicationProtocolNegotiationErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		header   string
+		errorStr string
+	}{
+		{
+			name:     "malformed protocol",
+			header:   "123",
+			errorStr: "webtransport: invalid WT-Protocol header",
+		},
+		{
+			name:     "protocol not offered",
+			header:   `"baz"`,
+			errorStr: `webtransport: server selected application protocol "baz" that wasn't offered`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &webtransport.Server{
+				H3: &http3.Server{
+					TLSConfig: webtransport.TLSConf,
+					QUICConfig: &quic.Config{
+						EnableDatagrams:                  true,
+						EnableStreamResetPartialDelivery: true,
+						Tracer:                           qlog.DefaultConnectionTracer,
+					},
+				},
+			}
+
+			s.H3.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("WT-Protocol", tc.header)
+				w.WriteHeader(http.StatusOK)
+				w.(http.Flusher).Flush()
+				<-r.Context().Done()
+			})
+
+			addr, closeServer := runServer(t, s)
+			defer closeServer()
+
+			d := webtransport.Dialer{
+				TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+				QUICConfig: &quic.Config{
+					EnableDatagrams:                  true,
+					EnableStreamResetPartialDelivery: true,
+					Tracer:                           qlog.DefaultConnectionTracer,
+				},
+				ApplicationProtocols: []string{"foo", "bar"},
+			}
+			defer d.Close()
+
+			url := fmt.Sprintf("https://localhost:%d/webtransport", addr.Port)
+			rsp, sess, err := d.Dial(context.Background(), url, nil)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.errorStr)
+			require.Nil(t, sess)
+			require.Equal(t, http.StatusOK, rsp.StatusCode)
+			var sessErr *webtransport.SessionError
+			require.ErrorAs(t, err, &sessErr)
+			require.False(t, sessErr.Remote)
+			require.Equal(t, webtransport.WTALPNErrorCode, sessErr.ErrorCode)
+		})
+	}
+}
+
 func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverProtocols []string, expected string) {
 	s := &webtransport.Server{
 		ApplicationProtocols: serverProtocols,


### PR DESCRIPTION
We only send this error when the server sends an obviously invalid protocol header. This error is not sent when the server omits the header value altogether.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WT_ALPN_ERROR` support to `Dialer` for failed protocol negotiation
> - `Dialer.handleConn` in [client.go](https://github.com/quic-go/webtransport-go/pull/277/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf) now validates the `WT-Protocol` response header after a 2xx: if the header is malformed or the server selects a protocol not offered by the client, it sends a `WT_CLOSE_SESSION` capsule and returns a `SessionError` with `WTALPNErrorCode` (0x0817b3dd).
> - `Dialer.negotiateProtocol` now returns `(string, error)` instead of silently accepting bad values.
> - A new `closeSessionStream` helper in [session.go](https://github.com/quic-go/webtransport-go/pull/277/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) encapsulates the capsule-send-and-cancel logic, making it reusable outside of `Session.CloseWithError`.
> - A new `WTALPNErrorCode` constant is added in [errors.go](https://github.com/quic-go/webtransport-go/pull/277/files#diff-76a7e0e299c7417bae32d3098e71370980157fe29e68a366671491d147d40572).
> - Behavioral Change: dials that previously succeeded (or silently ignored) a malformed or unacceptable `WT-Protocol` header will now fail with a `SessionError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f7e383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->