### PR TITLE
fix flaky TestDatagrams

### DIFF
--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -706,55 +707,84 @@ func TestWriteCloseRace(t *testing.T) {
 
 func TestDatagrams(t *testing.T) {
 	const num = 100
-	var mx sync.Mutex
-	m := make(map[string]bool, num)
+	const minReceived = num*4/5 + 1
 
-	var counter int
+	received := make(chan struct{}, num)
+	ready := make(chan struct{})
 	done := make(chan struct{})
 	serverErrChan := make(chan error, 1)
+	ctx, cancel := context.WithCancel(t.Context())
 	sess, closeServer := establishSession(t, func(sess *webtransport.Session) {
+		seen := make([]bool, num)
+		close(ready)
 		defer close(done)
 		for {
-			b, err := sess.ReceiveDatagram(context.Background())
+			b, err := sess.ReceiveDatagram(ctx)
 			if err != nil {
 				return
 			}
-			mx.Lock()
-			if _, ok := m[string(b)]; !ok {
-				serverErrChan <- errors.New("received unexpected datagram")
+			if len(b) != 800 {
+				serverErrChan <- fmt.Errorf("received datagram with length %d", len(b))
 				return
 			}
-			m[string(b)] = true
-			mx.Unlock()
-			counter++
+			n := binary.BigEndian.Uint64(b)
+			if n >= num {
+				serverErrChan <- fmt.Errorf("received datagram with unexpected number %d", n)
+				return
+			}
+			if seen[n] {
+				continue
+			}
+			seen[n] = true
+			received <- struct{}{}
 		}
 	})
 	defer closeServer()
+	defer cancel()
 
-	errChan := make(chan error, 1)
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
 
-	for range num {
+	var receivedCount int
+	for i := range num {
 		b := make([]byte, 800)
-		rand.Read(b)
-		mx.Lock()
-		m[string(b)] = false
-		mx.Unlock()
-		if err := sess.SendDatagram(b); err != nil {
-			break
+		binary.BigEndian.PutUint64(b, uint64(i))
+		require.NoError(t, sess.SendDatagram(b))
+		select {
+		case err := <-serverErrChan:
+			t.Fatal(err)
+		case <-received:
+			receivedCount++
+		case <-time.After(scaleDuration(50 * time.Millisecond)):
 		}
 	}
-	time.Sleep(scaleDuration(10 * time.Millisecond))
-	sess.CloseWithError(0, "")
+
+	timeout := time.After(5 * time.Second)
+	for receivedCount < minReceived {
+		select {
+		case err := <-serverErrChan:
+			t.Fatal(err)
+		case <-received:
+			receivedCount++
+		case <-timeout:
+			t.Fatalf("sent: %d, received: %d", num, receivedCount)
+		}
+	}
+
+	require.NoError(t, sess.CloseWithError(0, ""))
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
 	select {
 	case err := <-serverErrChan:
 		t.Fatal(err)
-	case err := <-errChan:
-		t.Fatal(err)
-	case <-done:
-		t.Logf("sent: %d, received: %d", num, counter)
-		require.Greater(t, counter, num*4/5)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timeout")
+	default:
 	}
 }
 


### PR DESCRIPTION
Fixes #237. Closes #238.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestDatagrams` by using deterministic payloads and a minimum receipt threshold
> - Replaces random payload generation and a shared map+mutex with fixed 800-byte payloads whose first 8 bytes encode the datagram index as a big-endian uint64.
> - Tracks first-time receipts on the server side and passes only when at least 80%+1 unique datagrams (`num*4/5 + 1`) are observed, tolerating expected UDP loss.
> - Uses a cancellable context for the server's `sess.ReceiveDatagram` loop so it terminates cleanly after the test completes.
> - Behavioral Change: the test no longer requires all sent datagrams to be received; it accepts any 80%+ unique subset within a 5-second window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b4e916.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->