### PR TITLE
use webtransport-h3 as the :protocol upgrade token

### DIFF
--- a/client.go
+++ b/client.go
@@ -101,7 +101,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	req := &http.Request{
 		Method: http.MethodConnect,
 		Header: reqHdr,
-		Proto:  "webtransport",
+		Proto:  protocolHeader,
 		Host:   u.Host,
 		URL:    u,
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -7,4 +7,17 @@ const settingsEnableWebtransportDraft06 = 0x2b603742
 // settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
 const settingsWebTransportEnabled = 0x2c7cf000
 
-const protocolHeader = "webtransport"
+const (
+	// protocolHeader is the Extended-CONNECT :protocol value per
+	// draft-ietf-webtrans-http3-15 §3.2, §9.1.
+	protocolHeader = "webtransport-h3"
+	// protocolHeaderLegacy is the pre-draft-13 value. Accepted by the server
+	// (but not sent by the client) for compat with peers that have not yet
+	// migrated — notably Chromium-based clients, which still send the legacy
+	// token (see net/quic/dedicated_web_transport_http3_client.cc).
+	protocolHeaderLegacy = "webtransport"
+)
+
+func isWebTransportProtocol(s string) bool {
+	return s == protocolHeader || s == protocolHeaderLegacy
+}

--- a/protocol.go
+++ b/protocol.go
@@ -11,10 +11,9 @@ const (
 	// protocolHeader is the Extended-CONNECT :protocol value per
 	// draft-ietf-webtrans-http3-15 §3.2, §9.1.
 	protocolHeader = "webtransport-h3"
-	// protocolHeaderLegacy is the pre-draft-13 value. Accepted by the server
-	// (but not sent by the client) for compat with peers that have not yet
-	// migrated — notably Chromium-based clients, which still send the legacy
-	// token (see net/quic/dedicated_web_transport_http3_client.cc).
+	// protocolHeaderLegacy is the pre-draft-15 value. Accepted by the server
+	// (but not sent by the client) for compatibility with peers that have not yet
+	// migrated.
 	protocolHeaderLegacy = "webtransport"
 )
 

--- a/server.go
+++ b/server.go
@@ -333,7 +333,7 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 	if r.Method != http.MethodConnect {
 		return nil, fmt.Errorf("expected CONNECT request, got %s", r.Method)
 	}
-	if r.Proto != protocolHeader {
+	if !isWebTransportProtocol(r.Proto) {
 		return nil, fmt.Errorf("unexpected protocol: %s", r.Proto)
 	}
 	if !s.CheckOrigin(r) {

--- a/server_test.go
+++ b/server_test.go
@@ -47,9 +47,6 @@ func TestUpgradeFailures(t *testing.T) {
 }
 
 func TestUpgradeProtocolAcceptance(t *testing.T) {
-	// The protocol check runs before the QUIC-connection lookup, so once the
-	// token is accepted Upgrade fails with "missing QUIC connection". That's
-	// the proof the token was accepted; we don't need real QUIC plumbing.
 	var s webtransport.Server
 
 	t.Run("accepts webtransport-h3", func(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -46,6 +46,34 @@ func TestUpgradeFailures(t *testing.T) {
 	})
 }
 
+func TestUpgradeProtocolAcceptance(t *testing.T) {
+	// The protocol check runs before the QUIC-connection lookup, so once the
+	// token is accepted Upgrade fails with "missing QUIC connection". That's
+	// the proof the token was accepted; we don't need real QUIC plumbing.
+	var s webtransport.Server
+
+	t.Run("accepts webtransport-h3", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodConnect, "/webtransport", nil)
+		req.Proto = "webtransport-h3"
+		_, err := s.Upgrade(httptest.NewRecorder(), req)
+		require.EqualError(t, err, "webtransport: missing QUIC connection")
+	})
+
+	t.Run("accepts legacy webtransport", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodConnect, "/webtransport", nil)
+		req.Proto = "webtransport"
+		_, err := s.Upgrade(httptest.NewRecorder(), req)
+		require.EqualError(t, err, "webtransport: missing QUIC connection")
+	})
+
+	t.Run("rejects unknown protocol", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodConnect, "/webtransport", nil)
+		req.Proto = "websocket"
+		_, err := s.Upgrade(httptest.NewRecorder(), req)
+		require.EqualError(t, err, "unexpected protocol: websocket")
+	})
+}
+
 //nolint:unparam
 func createStreamAndWrite(t *testing.T, conn *quic.Conn, sessionID uint64, data []byte) *quic.Stream {
 	t.Helper()

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -108,7 +108,7 @@ func NewWebTransportRequest(t *testing.T, addr string) *http.Request {
 	return &http.Request{
 		Method: http.MethodConnect,
 		Header: hdr,
-		Proto:  "webtransport",
+		Proto:  protocolHeader,
 		Host:   u.Host,
 		URL:    u,
 	}


### PR DESCRIPTION
Closes #279. _(Originally raised on my fork as tomholford/webtransport-go#19.)_

draft-ietf-webtrans-http3-15 §3.2 / §9.1 register the Extended-CONNECT
`:protocol` token as `webtransport-h3` (previously `webtransport`). This
mirrors the lenient-server / strict-client split #254 used for
`SETTINGS_WT_ENABLED`:

- **Server** (`protocol.go`, `server.go`): `Upgrade` now accepts both
  `webtransport-h3` and the legacy `webtransport`, so peers that haven't
  migrated still connect — notably Chromium-based clients, which still
  send the legacy token.
- **Client** (`client.go`): `Dialer.Dial` sends the canonical
  `webtransport-h3`.

The rejection error message is unchanged. `TestUpgradeProtocolAcceptance`
covers all three cases: new token accepted, legacy accepted, unknown
rejected.

## Validation

Verified empirically against current browsers using a local debug server
(tomholford/webtransport-go#18):

- **Chrome**: sends `:protocol = "webtransport"`; the legacy branch
  accepts it, end-to-end bidi + datagram pass.
- **Safari 26.5**: also sends `:protocol = "webtransport"` — contrary to
  the assumption in quic-go/webtransport-go#262 that Safari sends
  `webtransport-h3`. The legacy branch accepts it; Safari's actual
  handshake failure is the missing `SETTINGS_WT_MAX_SESSIONS`
  advertisement (quic-go/webtransport-go#261), not the token.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `webtransport-h3` as the `:protocol` upgrade token
> - Updates `protocolHeader` to `"webtransport-h3"` and introduces `protocolHeaderLegacy` (`"webtransport"`) for backward compatibility.
> - Adds `isWebTransportProtocol` helper that accepts either value, used in `Server.Upgrade` to validate incoming CONNECT requests.
> - The client's `Dialer.Dial` now sends `:protocol: webtransport-h3` instead of `webtransport`.
> - Behavioral Change: servers now accept both `webtransport-h3` and `webtransport`; clients will send the new token by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e56a5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
