### PR TITLE
test: drop dead Sec-Webtransport-Http3-Draft02 request header

### DIFF
--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -104,7 +104,6 @@ func NewWebTransportRequest(t *testing.T, addr string) *http.Request {
 	u, err := url.Parse(addr)
 	require.NoError(t, err)
 	hdr := make(http.Header)
-	hdr.Add("Sec-Webtransport-Http3-Draft02", "1")
 	return &http.Request{
 		Method: http.MethodConnect,
 		Header: hdr,


### PR DESCRIPTION
Follow-up to #280.

`Sec-Webtransport-Http3-Draft02` was the draft-02 header-based version
negotiation mechanism, removed in #191. The server no longer reads it,
and after #280 the only remaining reference to it in the tree was this
test helper (`NewWebTransportRequest`) — so setting the header had no
effect.

No behavior change: the helper still builds a valid WebTransport CONNECT
request.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead `Sec-Webtransport-Http3-Draft02` header from `NewWebTransportRequest` test helper
> Drops the `Sec-Webtransport-Http3-Draft02` header from the `NewWebTransportRequest` helper in [test_helpers_test.go](https://github.com/quic-go/webtransport-go/pull/282/files#diff-d11590e1e9d97e50647c9ea4b42a6277424e3ab782038df5d9f42a8150a56d11), which was no longer needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62c950d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->