### PR TITLE
implement validation of session IDs

### DIFF
--- a/client.go
+++ b/client.go
@@ -178,6 +178,10 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 				if err != nil {
 					return
 				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
 				sessMgr.AddStream(str, sessionID(id))
 			}()
 		}
@@ -207,6 +211,10 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 				id, err := quicvarint.Read(quicvarint.NewReader(str))
 				if err != nil {
 					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
 				sessMgr.AddUniStream(str, sessionID(id))

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -104,6 +105,61 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 	var appErr *quic.ApplicationError
 	require.True(t, errors.As(sErr, &appErr))
 	require.Equal(t, http3.ErrCodeFrameUnexpected, http3.ErrCode(appErr.ErrorCode))
+}
+
+func TestClientClosesConnectionForInvalidSessionID(t *testing.T) {
+	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true})
+	require.NoError(t, err)
+	defer ln.Close()
+	addr := fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port)
+
+	for _, tt := range []struct {
+		name       string
+		streamType uint64
+	}{{"bidirectional", webTransportFrameType}, {"unidirectional", webTransportUniStreamType}} {
+		t.Run(tt.name, func(t *testing.T) {
+			go func() {
+				d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+				_, _, _ = d.Dial(context.Background(), addr, nil)
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			conn, err := ln.Accept(ctx)
+			require.NoError(t, err)
+			defer conn.CloseWithError(0, "")
+			settingsStr, err := conn.OpenUniStream()
+			require.NoError(t, err)
+			_, err = settingsStr.Write(
+				appendSettingsFrame(
+					[]byte{0},
+					map[uint64]uint64{settingDatagram: 1, settingExtendedConnect: 1, settingsWebTransportEnabled: 1},
+				),
+			)
+			require.NoError(t, err)
+
+			var str io.WriteCloser
+			if tt.streamType == webTransportUniStreamType {
+				str, err = conn.OpenUniStream()
+			} else {
+				str, err = conn.OpenStream()
+			}
+			require.NoError(t, err)
+			_, err = str.Write(quicvarint.Append(quicvarint.Append(nil, tt.streamType), 1))
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			select {
+			case <-conn.Context().Done():
+				require.ErrorIs(t,
+					context.Cause(conn.Context()),
+					&quic.ApplicationError{ErrorCode: quic.ApplicationErrorCode(http3.ErrCodeIDError), Remote: true},
+				)
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for connection to close")
+			}
+		})
+	}
 }
 
 func TestClientWaitForSettingsTimeout(t *testing.T) {

--- a/protocol.go
+++ b/protocol.go
@@ -20,3 +20,10 @@ const (
 func isWebTransportProtocol(s string) bool {
 	return s == protocolHeader || s == protocolHeaderLegacy
 }
+
+// WebTransport session IDs are the stream IDs of the CONNECT requests that
+// establish the sessions. Those requests are sent on client-initiated
+// bidirectional streams, whose QUIC stream IDs are divisible by 4.
+func isValidSessionID(id uint64) bool {
+	return id%4 == 0
+}

--- a/server.go
+++ b/server.go
@@ -224,6 +224,10 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
 					return
 				}
+				if !isValidSessionID(id) {
+					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
 				sessMgr.AddStream(str, sessionID(id))
 			})
 		}
@@ -256,6 +260,10 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 				id, err := quicvarint.Read(r)
 				if err != nil {
 					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
 				sessMgr.AddUniStream(str, sessionID(id))

--- a/server_test.go
+++ b/server_test.go
@@ -21,7 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const webTransportFrameType = 0x41
+const (
+	webTransportFrameType     = 0x41
+	webTransportUniStreamType = 0x54
+)
 
 func scaleDuration(d time.Duration) time.Duration {
 	if os.Getenv("CI") != "" {
@@ -85,6 +88,55 @@ func createStreamAndWrite(t *testing.T, conn *quic.Conn, sessionID uint64, data 
 	require.NoError(t, err)
 	require.NoError(t, str.Close())
 	return str
+}
+
+func TestServerClosesConnectionForInvalidSessionID(t *testing.T) {
+	s := webtransport.Server{H3: &http3.Server{TLSConfig: webtransport.TLSConf}}
+	defer s.Close()
+
+	udpConn, err := net.ListenUDP("udp", nil)
+	require.NoError(t, err)
+	defer udpConn.Close()
+	webtransport.ConfigureHTTP3Server(s.H3)
+	go s.Serve(udpConn)
+	addr := fmt.Sprintf("localhost:%d", udpConn.LocalAddr().(*net.UDPAddr).Port)
+
+	for _, tt := range []struct {
+		name       string
+		streamType uint64
+	}{{"bidirectional", webTransportFrameType}, {"unidirectional", webTransportUniStreamType}} {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := quic.DialAddr(
+				context.Background(),
+				addr,
+				&tls.Config{RootCAs: webtransport.CertPool, NextProtos: []string{http3.NextProtoH3}},
+				&quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+			)
+			require.NoError(t, err)
+			defer conn.CloseWithError(0, "")
+
+			var str io.WriteCloser
+			if tt.streamType == webTransportUniStreamType {
+				str, err = conn.OpenUniStream()
+			} else {
+				str, err = conn.OpenStream()
+			}
+			require.NoError(t, err)
+			_, err = str.Write(quicvarint.Append(quicvarint.Append(nil, tt.streamType), 1))
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			select {
+			case <-conn.Context().Done():
+				require.ErrorIs(t,
+					context.Cause(conn.Context()),
+					&quic.ApplicationError{ErrorCode: quic.ApplicationErrorCode(http3.ErrCodeIDError), Remote: true},
+				)
+			case <-time.After(scaleDuration(time.Second)):
+				t.Fatal("timeout waiting for connection to close")
+			}
+		})
+	}
 }
 
 func TestServerReorderedUpgradeRequest(t *testing.T) {


### PR DESCRIPTION
WebTransport session IDs are the stream IDs of the CONNECT requests that establish the sessions. Those requests are sent on client-initiated bidirectional streams, whose QUIC stream IDs are divisible by 4.

No validation is needed for datagrams since datagrams are dispatched to the respective request streams at the quic-go layer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate WebTransport session IDs on both client and server
> - Adds `isValidSessionID` in [protocol.go](https://github.com/quic-go/webtransport-go/pull/283/files#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38) that checks a session ID is divisible by 4 (matching client-initiated bidirectional streams as required by the spec).
> - Both `Dialer.handleConn` in [client.go](https://github.com/quic-go/webtransport-go/pull/283/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf) and `Server.ServeQUICConn` in [server.go](https://github.com/quic-go/webtransport-go/pull/283/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6) now call this check after reading the session ID varint on incoming bidirectional and unidirectional WebTransport streams.
> - Invalid session IDs cause the QUIC connection to be closed with `http3.ErrCodeIDError` instead of the stream being accepted.
> - New tests in [client_test.go](https://github.com/quic-go/webtransport-go/pull/283/files#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3) and [server_test.go](https://github.com/quic-go/webtransport-go/pull/283/files#diff-53170cac6baf0bf02f3aaa3994259ea4cffaaf2498e768fb7e03cf9f752af96c) verify the connection is closed with the correct error code when session ID `1` is received.
> - Behavioral Change: previously invalid session IDs were silently accepted; they now terminate the connection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 904c6e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->