### PR TITLE
add an example server and client

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: CodeQL config
+
+paths-ignore:
+  - 'example/**'

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,33 @@
+name: Example
+permissions:
+  contents: read
+on: [push, pull_request]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    name: Example
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+      - name: Run client and server example
+        run: |
+          set -euo pipefail
+
+          server_log="$(mktemp)"
+          (cd example/server && go run . -protocols foobar) >"$server_log" 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+
+          sleep 5
+          cert_hash="$(sed -n 's/^Server Certificate Hash: //p' "$server_log" | head -n 1)"
+          if [ -z "$cert_hash" ]; then
+            cat "$server_log"
+            exit 1
+          fi
+
+          client_output="$(cd example/client && go run . -url https://localhost:6121/webtransport -protocols foobaz,foobar -cert-hash "$cert_hash")"
+          echo "$client_output"
+          printf '%s\n' "$client_output" | grep -q "negotiated protocol: foobar"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ webtransport-go is an implementation of the WebTransport protocol, based on [qui
 
 Detailed documentation can be found on [quic-go.net](https://quic-go.net/docs/).
 
+## Example
+
+A runnable client and server example is available in [`example`](./example).
 
 ## Projects using webtransport-go
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   ignore:
+    - example/
     - interop/
     - interop_chrome/
   status:

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,35 @@
+# WebTransport Example
+
+## Certificate
+
+The server deterministically generates a P-256 certificate. The certificate hash is stable for the current UTC week and rotates weekly to satisfy the W3C [`serverCertificateHashes` certificate-hash requirements](https://www.w3.org/TR/webtransport/#verify-a-certificate-hash), which limit certificate validity to less than two weeks. This is a browser API requirement, not a WebTransport protocol requirement.
+
+## Running the Server
+
+From the `server` directory:
+
+```bash
+go run .
+```
+
+This prints the base64-encoded certificate hash, serves the browser client at `http://localhost:6120`, and starts the WebTransport server at `https://localhost:6121/webtransport`.
+
+To use different listen addresses:
+
+By default, the server offers `webtransport-test,webtransport-test-2`. To change that:
+
+```bash
+go run . -protocols webtransport-test,webtransport-test-2
+```
+
+## Running the Go Client
+
+Start the server first. From the `client` directory:
+
+```bash
+go run . -url https://localhost:6121/webtransport -protocols webtransport-test
+```
+
+## Running the Browser Client
+
+Start the server first, then open `http://localhost:6120` in a browser. The server pre-fills the certificate hash, so click `Connect` to start the WebTransport session and see the status update.

--- a/example/README.md
+++ b/example/README.md
@@ -14,8 +14,6 @@ go run .
 
 This prints the base64-encoded certificate hash, serves the browser client at `http://localhost:6120`, and starts the WebTransport server at `https://localhost:6121/webtransport`.
 
-To use different listen addresses:
-
 By default, the server offers `webtransport-test,webtransport-test-2`. To change that:
 
 ```bash

--- a/example/README.md
+++ b/example/README.md
@@ -25,8 +25,10 @@ go run . -protocols webtransport-test,webtransport-test-2
 Start the server first. From the `client` directory:
 
 ```bash
-go run . -url https://localhost:6121/webtransport -protocols webtransport-test
+go run . -url https://localhost:6121/webtransport -protocols webtransport-test -cert-hash <server certificate hash>
 ```
+
+Use `-insecure` to skip certificate verification.
 
 ## Running the Browser Client
 

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/quic-go/webtransport-go"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3/qlog"
+)
+
+func main() {
+	if err := runClient(); err != nil {
+		log.Fatalf("failed to run client: %v", err)
+	}
+}
+
+func runClient() error {
+	url := flag.String("url", "https://localhost:6121/webtransport", "WebTransport URL")
+	protocolsFlag := flag.String("protocols", "webtransport-test,webtransport-test-2", "comma-separated application protocols")
+	flag.Parse()
+
+	var protocols []string
+	for p := range strings.SplitSeq(*protocolsFlag, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			protocols = append(protocols, p)
+		}
+	}
+
+	cl := &webtransport.Dialer{
+		ApplicationProtocols: protocols,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		QUICConfig: &quic.Config{
+			Tracer:                           qlog.DefaultConnectionTracer,
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	}
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rsp, sess, err := cl.Dial(ctx, *url, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(rsp.StatusCode)
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %d", rsp.StatusCode)
+	}
+	fmt.Printf("negotiated protocol: %s\n", sess.SessionState().ApplicationProtocol)
+	return nil
+}

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"log"
@@ -24,6 +26,8 @@ func main() {
 func runClient() error {
 	url := flag.String("url", "https://localhost:6121/webtransport", "WebTransport URL")
 	protocolsFlag := flag.String("protocols", "webtransport-test,webtransport-test-2", "comma-separated application protocols")
+	certHash := flag.String("cert-hash", "", "base64-encoded SHA-256 server certificate hash")
+	insecure := flag.Bool("insecure", false, "skip certificate verification")
 	flag.Parse()
 
 	var protocols []string
@@ -33,11 +37,24 @@ func runClient() error {
 		}
 	}
 
+	tlsConf := &tls.Config{InsecureSkipVerify: *insecure}
+	if hash := strings.TrimSpace(*certHash); hash != "" {
+		tlsConf.InsecureSkipVerify = true
+		tlsConf.VerifyConnection = func(state tls.ConnectionState) error {
+			if len(state.PeerCertificates) == 0 {
+				return fmt.Errorf("server didn't send a certificate")
+			}
+			actualHash := sha256.Sum256(state.PeerCertificates[0].Raw)
+			if got := base64.RawStdEncoding.EncodeToString(actualHash[:]); got != hash {
+				return fmt.Errorf("server certificate hash mismatch: got %s", got)
+			}
+			return nil
+		}
+	}
+
 	cl := &webtransport.Dialer{
 		ApplicationProtocols: protocols,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig:      tlsConf,
 		QUICConfig: &quic.Config{
 			Tracer:                           qlog.DefaultConnectionTracer,
 			EnableDatagrams:                  true,
@@ -52,7 +69,7 @@ func runClient() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(rsp.StatusCode)
+	fmt.Println("HTTP status code:", rsp.StatusCode)
 	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status: %d", rsp.StatusCode)
 	}

--- a/example/server/index.html
+++ b/example/server/index.html
@@ -26,20 +26,20 @@
         event.preventDefault();
         status.textContent = 'Connecting...';
 
-        const transport = new WebTransport('{{WEBTRANSPORT_URL}}', {
-          serverCertificateHashes: [{
-            algorithm: "sha-256",
-            value: base64ToBytes(input.value.trim()),
-          }]
-        });
-
-        transport.closed.then(() => {
-          console.log('The HTTP/3 connection closed gracefully.');
-        }).catch((error) => {
-          console.error('The HTTP/3 connection closed due to ' + error + '.');
-        });
-
         try {
+          const transport = new WebTransport('{{WEBTRANSPORT_URL}}', {
+            serverCertificateHashes: [{
+              algorithm: "sha-256",
+              value: base64ToBytes(input.value.trim()),
+            }]
+          });
+
+          transport.closed.then(() => {
+            console.log('The HTTP/3 connection closed gracefully.');
+          }).catch((error) => {
+            console.error('The HTTP/3 connection closed due to ' + error + '.');
+          });
+
           await transport.ready;
           status.textContent = 'Connected.';
           console.log('The HTTP/3 connection is ready.');

--- a/example/server/index.html
+++ b/example/server/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <form id="connect-form">
+      <label for="certhash-input">Certificate Hash (base64):</label>
+      <input type="text" id="certhash-input" name="certhash" value="{{SERVER_CERTIFICATE_HASH}}">
+      <button type="submit">Connect</button>
+    </form>
+    <div id="status">Not connected.</div>
+
+    <script type="module">
+      function base64ToBytes(base64) {
+        const binaryString = atob(base64);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        return bytes;
+      }
+
+      const status = document.getElementById('status');
+      const form = document.getElementById('connect-form');
+      const input = document.getElementById('certhash-input');
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        status.textContent = 'Connecting...';
+
+        const transport = new WebTransport('{{WEBTRANSPORT_URL}}', {
+          serverCertificateHashes: [{
+            algorithm: "sha-256",
+            value: base64ToBytes(input.value.trim()),
+          }]
+        });
+
+        transport.closed.then(() => {
+          console.log('The HTTP/3 connection closed gracefully.');
+        }).catch((error) => {
+          console.error('The HTTP/3 connection closed due to ' + error + '.');
+        });
+
+        try {
+          await transport.ready;
+          status.textContent = 'Connected.';
+          console.log('The HTTP/3 connection is ready.');
+          console.log(transport);
+        } catch (error) {
+          status.textContent = 'Connection failed.';
+          console.error(error);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	_ "embed"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/quic-go/webtransport-go"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/http3/qlog"
+)
+
+//go:embed index.html
+var browserIndex string
+
+func main() {
+	addr := flag.String("addr", ":6121", "WebTransport listen address")
+	browserAddr := flag.String("browser-addr", ":6120", "browser client listen address")
+	protocolsFlag := flag.String("protocols", "webtransport-test,webtransport-test-2", "comma-separated application protocols")
+	flag.Parse()
+
+	var protocols []string
+	for p := range strings.SplitSeq(*protocolsFlag, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			protocols = append(protocols, p)
+		}
+	}
+
+	privateKeyBytes := []byte("webtransport-example-cert-key-01")
+	certKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), privateKeyBytes)
+	if err != nil {
+		log.Fatalf("failed to create certificate key: %v", err)
+	}
+
+	// The W3C serverCertificateHashes API requires the certificate to be valid now,
+	// but for less than two weeks. A weekly window keeps the hash stable across restarts.
+	now := time.Now().UTC()
+	validFrom := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	validFrom = validFrom.AddDate(0, 0, -int((validFrom.Weekday()+6)%7))
+	validUntil := validFrom.Add(13 * 24 * time.Hour)
+
+	certTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(validFrom.Unix()),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             validFrom,
+		NotAfter:              validUntil,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.ParseIP("::1")},
+	}
+	// Passing nil makes ECDSA signing deterministic according to RFC 6979.
+	certDER, err := x509.CreateCertificate(nil, &certTemplate, &certTemplate, &certKey.PublicKey, certKey)
+	if err != nil {
+		log.Fatalf("failed to create certificate: %v", err)
+	}
+
+	hash := sha256.Sum256(certDER)
+	certHash := base64.RawStdEncoding.EncodeToString(hash[:])
+	fmt.Printf("Server Certificate Hash: %s\n", certHash)
+
+	tlsConf := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  certKey,
+		}},
+	}
+	if err := runServer(tlsConf, certHash, *addr, *browserAddr, protocols); err != nil {
+		log.Fatalf("failed to run server: %v", err)
+	}
+}
+
+func runServer(tlsConf *tls.Config, certHash, addr, browserAddr string, protocols []string) error {
+	webTransportAddr := addr
+	if host, port, err := net.SplitHostPort(addr); err == nil && host == "" {
+		webTransportAddr = net.JoinHostPort("localhost", port)
+	}
+	webTransportURL := "https://" + webTransportAddr + "/webtransport"
+
+	browserURL := browserAddr
+	if host, port, err := net.SplitHostPort(browserAddr); err == nil && host == "" {
+		browserURL = net.JoinHostPort("localhost", port)
+	}
+
+	browserHTML := strings.ReplaceAll(browserIndex, "{{SERVER_CERTIFICATE_HASH}}", certHash)
+	browserHTML = strings.ReplaceAll(browserHTML, "{{WEBTRANSPORT_URL}}", webTransportURL)
+
+	go func() {
+		log.Printf("serving browser client on http://%s", browserURL)
+		if err := http.ListenAndServe(browserAddr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprint(w, browserHTML)
+		})); err != nil {
+			log.Printf("serving browser client failed: %s", err)
+		}
+	}()
+
+	h3Server := &http3.Server{
+		Addr:      addr,
+		TLSConfig: http3.ConfigureTLSConfig(tlsConf),
+		QUICConfig: &quic.Config{
+			Tracer:                           qlog.DefaultConnectionTracer,
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	}
+	webtransport.ConfigureHTTP3Server(h3Server)
+	mux := http.NewServeMux()
+	h3Server.Handler = mux
+
+	s := webtransport.Server{
+		ApplicationProtocols: protocols,
+		H3:                   h3Server,
+		CheckOrigin:          func(*http.Request) bool { return true },
+	}
+
+	// Create a new HTTP endpoint /webtransport.
+	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
+		sess, err := s.Upgrade(w, r)
+		if err != nil {
+			log.Printf("upgrading failed: %s", err)
+			w.WriteHeader(500)
+			return
+		}
+		fmt.Printf("negotiated protocol: %s\n", sess.SessionState().ApplicationProtocol)
+	})
+
+	log.Printf("listening on %s", webTransportURL)
+	return s.ListenAndServe()
+}


### PR DESCRIPTION
The example server serves an (almost) static HTML page to facilitate browser testing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add example WebTransport server and client
> - Adds a self-signed-certificate WebTransport server ([example/server/main.go](https://github.com/quic-go/webtransport-go/pull/285/files#diff-744db701353ee3a906e1e5a143d8252514d64f4c5d08c142b8f4abd21a95242e)) that serves a `/webtransport` upgrade endpoint and logs the negotiated application protocol, plus a browser UI ([example/server/index.html](https://github.com/quic-go/webtransport-go/pull/285/files#diff-42655e6d9fa24a086d1f7b5e13895d4b7dcd8051f1a8d6803e77130d038bc408)) for manual testing.
> - Adds a CLI client ([example/client/main.go](https://github.com/quic-go/webtransport-go/pull/285/files#diff-e65d47f74036d30a061631f026c57161d1b77bed2a56b064bdf51fc18734bb34)) that dials a WebTransport URL with optional protocol negotiation and certificate hash pinning.
> - Adds a CI workflow ([.github/workflows/example.yml](https://github.com/quic-go/webtransport-go/pull/285/files#diff-d6ed008bccc277977568760d40099e6ddfdc2e8d47874752724c33f2676588e3)) that runs the server and client end-to-end and asserts the negotiated protocol is `foobar`.
> - CodeQL and Codecov are configured to ignore the `example/` directory.
> - Risk: the client references `strings.SplitSeq` and the server references `ecdsa.ParseRawPrivateKey`, neither of which exist in the standard library — both files will fail to compile as written.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bfba62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->