### PR TITLE
fix session closed regressions in 0.11

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -26,6 +26,32 @@ var (
 	_ quicSendStream = &quic.Stream{}
 )
 
+// sessionGoneGracePeriod bounds how long a Read or Write blocks after the peer
+// resets the stream with WT_SESSION_GONE, waiting for the WT_CLOSE_SESSION
+// capsule to arrive on the CONNECT stream (which lets us surface the precise
+// session-close error).
+//
+// Normally the stream reset and the close capsule are delivered together (often
+// coalesced in the same packet), so s.closed fires almost immediately. However,
+// if the peer signals "session gone" at the stream level but never completes the
+// session-close handshake (e.g. it is shutting down and the process goes away),
+// s.closed would never fire. Without this bound, and with no read/write deadline
+// set, the call would block until the QUIC idle timeout (or indefinitely). After
+// the grace period elapses we surface a generic session-gone error instead.
+//
+// It is a variable rather than a constant so it can be overridden in tests.
+var sessionGoneGracePeriod = 100 * time.Millisecond
+
+// errSessionGone is returned from Read/Write when the stream was reset with
+// WT_SESSION_GONE but the peer never delivered the WT_CLOSE_SESSION capsule
+// within sessionGoneGracePeriod.
+func errSessionGone() error {
+	return &SessionError{
+		Remote:  true,
+		Message: "session gone: WT_SESSION_GONE received without WT_CLOSE_SESSION capsule",
+	}
+}
+
 type quicReceiveStream interface {
 	io.Reader
 	CancelRead(quic.StreamErrorCode)
@@ -96,6 +122,10 @@ func (s *SendStream) handleSessionGoneError() error {
 	}
 	s.deadlineMu.Unlock()
 
+	// Bound the wait for the session-close capsule so a vanished peer can't make this block indefinitely.
+	// See sessionGoneGracePeriod for details.
+	graceTimer := time.NewTimer(sessionGoneGracePeriod)
+
 	for {
 		s.deadlineMu.Lock()
 		deadline := s.writeDeadline
@@ -114,6 +144,8 @@ func (s *SendStream) handleSessionGoneError() error {
 			return s.closeErr
 		case <-timerCh:
 			return os.ErrDeadlineExceeded
+		case <-graceTimer.C:
+			return errSessionGone()
 		case <-s.deadlineNotifyCh:
 		}
 	}
@@ -299,6 +331,10 @@ func (s *ReceiveStream) handleSessionGoneError() error {
 	}
 	s.deadlineMu.Unlock()
 
+	// Bound the wait for the session-close capsule so a vanished peer can't make this block indefinitely.
+	// See sessionGoneGracePeriod for details.
+	graceTimer := time.NewTimer(sessionGoneGracePeriod)
+
 	for {
 		s.deadlineMu.Lock()
 		deadline := s.readDeadline
@@ -317,6 +353,8 @@ func (s *ReceiveStream) handleSessionGoneError() error {
 			return s.closeErr
 		case <-timerCh:
 			return os.ErrDeadlineExceeded
+		case <-graceTimer.C:
+			return errSessionGone()
 		case <-s.deadlineNotifyCh:
 		}
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// setSessionGoneGracePeriod overrides sessionGoneGracePeriod for the duration of the test
+func setSessionGoneGracePeriod(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := sessionGoneGracePeriod
+	sessionGoneGracePeriod = d
+	t.Cleanup(func() {
+		sessionGoneGracePeriod = old
+	})
+}
+
 func newUniStreamPair(t *testing.T) (*quic.SendStream, *quic.ReceiveStream) {
 	t.Helper()
 
@@ -78,6 +88,7 @@ func TestSendStreamClose(t *testing.T) {
 }
 
 func TestSendStreamSessionGone(t *testing.T) {
+	setSessionGoneGracePeriod(t, time.Hour)
 	sendStr, recvStr := newUniStreamPair(t)
 	str := newSendStream(sendStr, nil, func() {})
 
@@ -113,6 +124,7 @@ func TestSendStreamSessionGone(t *testing.T) {
 
 func TestSendStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
+		setSessionGoneGracePeriod(t, time.Hour)
 		sendStr, recvStr := newUniStreamPair(t)
 		str := newSendStream(sendStr, nil, func() {})
 
@@ -139,6 +151,7 @@ func TestSendStreamSessionGoneDeadline(t *testing.T) {
 	})
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
+		setSessionGoneGracePeriod(t, time.Hour)
 		sendStr, recvStr := newUniStreamPair(t)
 		str := newSendStream(sendStr, nil, func() {})
 
@@ -173,6 +186,7 @@ func TestSendStreamSessionGoneDeadline(t *testing.T) {
 }
 
 func TestReceiveStreamSessionGone(t *testing.T) {
+	setSessionGoneGracePeriod(t, time.Hour)
 	sendStr, recvStr := newUniStreamPair(t)
 	str := newReceiveStream(recvStr, func() {})
 
@@ -204,6 +218,7 @@ func TestReceiveStreamSessionGone(t *testing.T) {
 }
 
 func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
+	setSessionGoneGracePeriod(t, time.Hour)
 	sendStr, recvStr := newUniStreamPair(t)
 
 	sm := newStreamsMap()
@@ -240,6 +255,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 
 func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
+		setSessionGoneGracePeriod(t, time.Hour)
 		sendStr, recvStr := newUniStreamPair(t)
 		str := newReceiveStream(recvStr, func() {})
 
@@ -263,6 +279,7 @@ func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 	})
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
+		setSessionGoneGracePeriod(t, time.Hour)
 		sendStr, recvStr := newUniStreamPair(t)
 		str := newReceiveStream(recvStr, func() {})
 
@@ -328,6 +345,7 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 }
 
 func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
+	setSessionGoneGracePeriod(t, time.Hour)
 	sendStr, recvStr := newUniStreamPair(t)
 
 	sm := newStreamsMap()
@@ -364,6 +382,62 @@ func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 		require.ErrorIs(t, err, sessionErr)
 	case <-time.After(scaleDuration(time.Second)):
 		t.Fatal("Write() should not hang after CloseSession()")
+	}
+}
+
+func TestReceiveStreamSessionGoneGracePeriod(t *testing.T) {
+	setSessionGoneGracePeriod(t, scaleDuration(20*time.Millisecond))
+
+	sendStr, recvStr := newUniStreamPair(t)
+	str := newReceiveStream(recvStr, func() {})
+
+	// simulate remote side sending WTSessionGoneErrorCode
+	sendStr.CancelWrite(WTSessionGoneErrorCode)
+
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := str.Read(make([]byte, 100))
+		errChan <- err
+	}()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, &SessionError{Remote: true})
+		var sessErr *SessionError
+		require.ErrorAs(t, err, &sessErr)
+		require.True(t, sessErr.Remote)
+	case <-time.After(scaleDuration(2 * time.Second)):
+		t.Fatal("Read should have unblocked after the grace period")
+	}
+}
+
+func TestSendStreamSessionGoneGracePeriod(t *testing.T) {
+	setSessionGoneGracePeriod(t, scaleDuration(20*time.Millisecond))
+
+	sendStr, recvStr := newUniStreamPair(t)
+	str := newSendStream(sendStr, nil, func() {})
+
+	// simulate remote side sending WTSessionGoneErrorCode
+	recvStr.CancelRead(WTSessionGoneErrorCode)
+
+	errChan := make(chan error, 1)
+	go func() {
+		for {
+			if _, err := str.Write([]byte("foo")); err != nil {
+				errChan <- err
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		var sessErr *SessionError
+		require.ErrorAs(t, err, &sessErr)
+		require.True(t, sessErr.Remote)
+	case <-time.After(scaleDuration(2 * time.Second)):
+		t.Fatal("Write should have unblocked after the grace period")
 	}
 }
 


### PR DESCRIPTION
This PR fixes a regression in 0.11 that caused issues with closing a session. These have manifested as bugs in my app.

When a stream is reset with WT_SESSION_GONE, Read and Write block in handleSessionGoneError waiting for the WT_CLOSE_SESSION capsule on the CONNECT stream so the precise session-close error can be surfaced.
If the peer signals "session gone" at the stream level but never completes the session-close handshake (e.g. it is shutting down and the process goes away), s.closed never fires.
With no read/write deadline set, the call blocked until the QUIC idle timeout (or indefinitely), a regression from 0.10.0, which surfaced the session-gone error immediately.

Bound the wait with a grace period (default 100ms). Normally the stream reset and the close capsule are delivered together, so s.closed fires almost immediately and the precise error is still returned.
When the peer has vanished, the grace period elapses and a generic session-gone SessionError is returned instead of hanging.

Added unit test to validate behavior and prevent future regressions.

> Disclosure: PR was created with help from AI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix session-gone regressions by bounding `Read`/`Write` wait with a grace period
> - Adds a `sessionGoneGracePeriod` (100ms) that limits how long `SendStream` and `ReceiveStream` block after receiving a `WT_SESSION_GONE` reset before returning a `*SessionError`.
> - Previously, streams could block indefinitely (until a deadline or idle timeout) when `WT_SESSION_GONE` arrived without a subsequent `WT_CLOSE_SESSION` capsule.
> - Adds `errSessionGone()` to construct a remote `*SessionError` returned when the grace period elapses without session closure.
> - Existing tests that rely on blocking behavior after `WT_SESSION_GONE` are updated to set the grace period to 1 hour to avoid interference.
> - Behavioral Change: `Read`/`Write` now unblocks after 100ms on `WT_SESSION_GONE` without closure, where previously it would block until a deadline or timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9464da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->