### PR TITLE
extract capsule parsing into a separate file

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -3,6 +3,7 @@ package webtransport
 import (
 	"encoding/binary"
 	"io"
+	"unicode/utf8"
 
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -44,4 +45,26 @@ func parseNextCapsule(r io.Reader) error {
 			}
 		}
 	}
+}
+
+func appendCloseSessionCapsulePayload(b []byte, code SessionErrorCode, msg string) []byte {
+	if len(msg) > maxCloseCapsuleErrorMsgLen {
+		msg = truncateUTF8(msg, maxCloseCapsuleErrorMsgLen)
+	}
+
+	payloadStart := len(b)
+	b = append(b, 0, 0, 0, 0)
+	binary.BigEndian.PutUint32(b[payloadStart:], uint32(code))
+	return append(b, msg...)
+}
+
+// truncateUTF8 cuts a string to max n bytes without breaking UTF-8 characters.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }

--- a/capsule.go
+++ b/capsule.go
@@ -13,8 +13,8 @@ const closeSessionCapsuleType http3.CapsuleType = 0x2843
 
 const maxCloseCapsuleErrorMsgLen = 1024
 
-// parseNextCapsule parses the next Capsule sent on the request stream.
-// It returns a SessionError, if the capsule received is a WT_CLOSE_SESSION Capsule.
+// parseNextCapsule parses Capsules sent on the request stream.
+// It returns a SessionError when it receives a WT_CLOSE_SESSION Capsule.
 func parseNextCapsule(r io.Reader) error {
 	for {
 		typ, capsuleReader, err := http3.ParseCapsule(quicvarint.NewReader(r))

--- a/capsule.go
+++ b/capsule.go
@@ -1,0 +1,47 @@
+package webtransport
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+const closeSessionCapsuleType http3.CapsuleType = 0x2843
+
+const maxCloseCapsuleErrorMsgLen = 1024
+
+// parseNextCapsule parses the next Capsule sent on the request stream.
+// It returns a SessionError, if the capsule received is a WT_CLOSE_SESSION Capsule.
+func parseNextCapsule(r io.Reader) error {
+	for {
+		typ, capsuleReader, err := http3.ParseCapsule(quicvarint.NewReader(r))
+		if err != nil {
+			return err
+		}
+		switch typ {
+		case closeSessionCapsuleType:
+			var b [4]byte
+			if _, err := io.ReadFull(capsuleReader, b[:]); err != nil {
+				return err
+			}
+			appErrCode := binary.BigEndian.Uint32(b[:])
+			// the length of the error message is limited to 1024 bytes
+			appErrMsg, err := io.ReadAll(io.LimitReader(capsuleReader, maxCloseCapsuleErrorMsgLen))
+			if err != nil {
+				return err
+			}
+			return &SessionError{
+				Remote:    true,
+				ErrorCode: SessionErrorCode(appErrCode),
+				Message:   string(appErrMsg),
+			}
+		default:
+			// unknown capsule, skip it
+			if _, err := io.Copy(io.Discard, capsuleReader); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -29,3 +29,39 @@ func TestParseCloseSessionCapsuleMessageTruncation(t *testing.T) {
 	require.Len(t, sessErr.Message, maxCloseCapsuleErrorMsgLen)
 	require.Equal(t, strings.Repeat("b", maxCloseCapsuleErrorMsgLen), sessErr.Message)
 }
+
+func TestAppendCloseSessionCapsulePayloadMessageTruncation(t *testing.T) {
+	payload := appendCloseSessionCapsulePayload(nil, 42, strings.Repeat("a", maxCloseCapsuleErrorMsgLen+500))
+
+	require.Len(t, payload, 4+maxCloseCapsuleErrorMsgLen)
+	require.Equal(t, uint32(42), binary.BigEndian.Uint32(payload[:4]))
+	require.Equal(t, strings.Repeat("a", maxCloseCapsuleErrorMsgLen), string(payload[4:]))
+}
+
+func TestCloseSessionCapsuleRoundTrip(t *testing.T) {
+	var b bytes.Buffer
+	payload := appendCloseSessionCapsulePayload(nil, 42, "all good")
+	require.NoError(t, http3.WriteCapsule(quicvarint.NewWriter(&b), closeSessionCapsuleType, payload))
+
+	err := parseNextCapsule(&b)
+	var sessErr *SessionError
+	require.ErrorAs(t, err, &sessErr)
+	require.True(t, sessErr.Remote)
+	require.Equal(t, SessionErrorCode(42), sessErr.ErrorCode)
+	require.Equal(t, "all good", sessErr.Message)
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	input := "Go 🚀"
+	require.Len(t, input, 7)
+
+	require.Equal(t, "Go 🚀", truncateUTF8(input, 100))
+	require.Equal(t, "Go 🚀", truncateUTF8(input, 7))
+	require.Equal(t, "Go ", truncateUTF8(input, 6))
+	require.Equal(t, "Go ", truncateUTF8(input, 5))
+	require.Equal(t, "Go ", truncateUTF8(input, 4))
+	require.Equal(t, "Go ", truncateUTF8(input, 3))
+	require.Equal(t, "Go", truncateUTF8(input, 2))
+	require.Equal(t, "G", truncateUTF8(input, 1))
+	require.Equal(t, "", truncateUTF8(input, 0))
+}

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -1,0 +1,31 @@
+package webtransport
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCloseSessionCapsuleMessageTruncation(t *testing.T) {
+	longMsg := strings.Repeat("b", maxCloseCapsuleErrorMsgLen+500)
+	payload := make([]byte, 4+len(longMsg))
+	binary.BigEndian.PutUint32(payload[:4], uint32(1337))
+	copy(payload[4:], longMsg)
+
+	var b bytes.Buffer
+	require.NoError(t, http3.WriteCapsule(quicvarint.NewWriter(&b), closeSessionCapsuleType, payload))
+
+	err := parseNextCapsule(&b)
+	var sessErr *SessionError
+	require.ErrorAs(t, err, &sessErr)
+	require.True(t, sessErr.Remote)
+	require.Equal(t, SessionErrorCode(1337), sessErr.ErrorCode)
+	require.Len(t, sessErr.Message, maxCloseCapsuleErrorMsgLen)
+	require.Equal(t, strings.Repeat("b", maxCloseCapsuleErrorMsgLen), sessErr.Message)
+}

--- a/session.go
+++ b/session.go
@@ -2,13 +2,11 @@ package webtransport
 
 import (
 	"context"
-	"encoding/binary"
 	"io"
 	"math/rand/v2"
 	"net"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -366,20 +364,12 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 }
 
 func closeSessionStream(str http3Stream, code SessionErrorCode, msg string) error {
-	// truncate the message if it's too long
-	if len(msg) > maxCloseCapsuleErrorMsgLen {
-		msg = truncateUTF8(msg, maxCloseCapsuleErrorMsgLen)
-	}
-
-	b := make([]byte, 4, 4+len(msg))
-	binary.BigEndian.PutUint32(b, uint32(code))
-	b = append(b, []byte(msg)...)
-
 	// Optimistically send the WT_CLOSE_SESSION Capsule:
 	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
 	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
 	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
-	if err := http3.WriteCapsule(quicvarint.NewWriter(str), closeSessionCapsuleType, b); err != nil {
+	payload := appendCloseSessionCapsulePayload(nil, code, msg)
+	if err := http3.WriteCapsule(quicvarint.NewWriter(str), closeSessionCapsuleType, payload); err != nil {
 		str.CancelWrite(WTSessionGoneErrorCode)
 	}
 
@@ -418,16 +408,4 @@ func (s *Session) SessionState() SessionState {
 		ConnectionState:     s.conn.ConnectionState(),
 		ApplicationProtocol: s.applicationProtocol,
 	}
-}
-
-// truncateUTF8 cuts a string to max n bytes without breaking UTF-8 characters.
-func truncateUTF8(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-
-	for n > 0 && !utf8.RuneStart(s[n]) {
-		n--
-	}
-	return s[:n]
 }

--- a/session.go
+++ b/session.go
@@ -18,10 +18,6 @@ import (
 // sessionID is the WebTransport Session ID
 type sessionID uint64
 
-const closeSessionCapsuleType http3.CapsuleType = 0x2843
-
-const maxCloseCapsuleErrorMsgLen = 1024
-
 type acceptQueue[T any] struct {
 	mx sync.Mutex
 	// The channel is used to notify consumers (via Chan) about new incoming items.
@@ -138,42 +134,8 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 }
 
 func (s *Session) handleConn() {
-	err := s.parseNextCapsule()
+	err := parseNextCapsule(s.str)
 	s.closeWithError(err)
-}
-
-// parseNextCapsule parses the next Capsule sent on the request stream.
-// It returns a SessionError, if the capsule received is a WT_CLOSE_SESSION Capsule.
-func (s *Session) parseNextCapsule() error {
-	for {
-		typ, r, err := http3.ParseCapsule(quicvarint.NewReader(s.str))
-		if err != nil {
-			return err
-		}
-		switch typ {
-		case closeSessionCapsuleType:
-			var b [4]byte
-			if _, err := io.ReadFull(r, b[:]); err != nil {
-				return err
-			}
-			appErrCode := binary.BigEndian.Uint32(b[:])
-			// the length of the error message is limited to 1024 bytes
-			appErrMsg, err := io.ReadAll(io.LimitReader(r, maxCloseCapsuleErrorMsgLen))
-			if err != nil {
-				return err
-			}
-			return &SessionError{
-				Remote:    true,
-				ErrorCode: SessionErrorCode(appErrCode),
-				Message:   string(appErrMsg),
-			}
-		default:
-			// unknown capsule, skip it
-			if _, err := io.Copy(io.Discard, r); err != nil {
-				return err
-			}
-		}
-	}
 }
 
 func (s *Session) addStream(qstr *quic.Stream, addStreamHeader bool) *Stream {

--- a/session_test.go
+++ b/session_test.go
@@ -344,67 +344,6 @@ func TestCloseWithErrorTruncatesSendMessage(t *testing.T) {
 	}
 }
 
-// TestCloseWithErrorTruncatesReceiveMessage tests that when receiving a close capsule
-// with a message longer than 1024 bytes, the session truncates the message.
-func TestCloseWithErrorTruncatesReceiveMessage(t *testing.T) {
-	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-
-	longMsg := strings.Repeat("b", maxCloseCapsuleErrorMsgLen+500)
-
-	server := &http3.Server{}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.(http.Flusher).Flush()
-
-		payload := make([]byte, 4+len(longMsg))
-		binary.BigEndian.PutUint32(payload[:4], uint32(1337))
-		copy(payload[4:], longMsg)
-
-		if err := http3.WriteCapsule(quicvarint.NewWriter(w), closeSessionCapsuleType, payload); err != nil {
-			t.Errorf("failed to write capsule: %v", err)
-		}
-		w.(http.Flusher).Flush()
-	})
-	server.Handler = mux
-	t.Cleanup(func() { server.Close() })
-	go server.ServeQUICConn(serverConn)
-
-	serverAddr := fmt.Sprintf("https://localhost:%d/webtransport", serverConn.LocalAddr().(*net.UDPAddr).Port)
-
-	tr := &http3.Transport{}
-	conn := tr.NewClientConn(clientConn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	reqStr, err := conn.OpenRequestStream(ctx)
-	require.NoError(t, err)
-	require.NoError(t, reqStr.SendRequestHeader(NewWebTransportRequest(t, serverAddr)))
-	rsp, err := reqStr.ReadResponse()
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, rsp.StatusCode)
-
-	sess := newSession(context.Background(), 42, clientConn, reqStr, "")
-
-	select {
-	case <-sess.Context().Done():
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for session to close")
-	}
-
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel2()
-	_, err = sess.AcceptStream(ctx2)
-	require.Error(t, err)
-
-	var sessErr *SessionError
-	require.ErrorAs(t, err, &sessErr)
-	require.True(t, sessErr.Remote)
-	require.Equal(t, SessionErrorCode(1337), sessErr.ErrorCode)
-	// the message should be truncated to maxCloseCapsuleErrorMsgLen
-	require.Len(t, sessErr.Message, maxCloseCapsuleErrorMsgLen)
-	require.Equal(t, strings.Repeat("b", maxCloseCapsuleErrorMsgLen), sessErr.Message)
-}
-
 func TestTruncateUTF8(t *testing.T) {
 	input := "Go 🚀"
 	require.Len(t, input, 7)

--- a/session_test.go
+++ b/session_test.go
@@ -343,18 +343,3 @@ func TestCloseWithErrorTruncatesSendMessage(t *testing.T) {
 		t.Fatal("timeout waiting for capsule")
 	}
 }
-
-func TestTruncateUTF8(t *testing.T) {
-	input := "Go 🚀"
-	require.Len(t, input, 7)
-
-	require.Equal(t, "Go 🚀", truncateUTF8(input, 100))
-	require.Equal(t, "Go 🚀", truncateUTF8(input, 7))
-	require.Equal(t, "Go ", truncateUTF8(input, 6))
-	require.Equal(t, "Go ", truncateUTF8(input, 5))
-	require.Equal(t, "Go ", truncateUTF8(input, 4))
-	require.Equal(t, "Go ", truncateUTF8(input, 3))
-	require.Equal(t, "Go", truncateUTF8(input, 2))
-	require.Equal(t, "G", truncateUTF8(input, 1))
-	require.Equal(t, "", truncateUTF8(input, 0))
-}


### PR DESCRIPTION
No functional change expected.

This will keep things neat and tidy once we implement the capsule parsing logic for flow control capsules (#256).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract capsule parsing into a separate file in the webtransport package
> Moves capsule-related logic out of [session.go](https://github.com/quic-go/webtransport-go/pull/289/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) into a new [capsule.go](https://github.com/quic-go/webtransport-go/pull/289/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6) file. The constants `closeSessionCapsuleType` and `maxCloseCapsuleErrorMsgLen`, the `truncateUTF8` helper, and the capsule parse/build logic are now top-level functions (`parseNextCapsule`, `appendCloseSessionCapsulePayload`) rather than methods on `Session`. Tests are moved to a new [capsule_test.go](https://github.com/quic-go/webtransport-go/pull/289/files#diff-1fedf59acd53c997fec7b23fb3c1c7a0cca51168dcf963a0149468d27cc9b3b9) with equivalent coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df21284.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->