### PR TITLE
avoid buffering skipped capsules

### DIFF
--- a/session.go
+++ b/session.go
@@ -169,7 +169,7 @@ func (s *Session) parseNextCapsule() error {
 			}
 		default:
 			// unknown capsule, skip it
-			if _, err := io.ReadAll(r); err != nil {
+			if _, err := io.Copy(io.Discard, r); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Discard unknown capsule payloads by streaming instead of buffering
In `Session.parseNextCapsule`, unknown capsule types previously used `io.ReadAll` to drain the payload, allocating a buffer for the full contents. This replaces that with `io.Copy(io.Discard, r)` to stream-discard the payload without buffering it in memory.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a11623.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->