### PR TITLE
implement parsing and serialization of WT_MAX_STREAMS capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -123,16 +123,15 @@ func (c maxStreamsUniCapsule) Append(b []byte) []byte {
 }
 
 func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {
-	b, err := io.ReadAll(r)
+	maxStreams, err := quicvarint.Read(quicvarint.NewReader(r))
 	if err != nil {
 		return 0, err
 	}
-	maxStreams, n, err := quicvarint.Parse(b)
-	if err != nil {
-		return 0, err
-	}
-	if n != len(b) {
+	var extra [1]byte
+	if _, err := io.ReadFull(r, extra[:]); err == nil {
 		return 0, errors.New("WT_MAX_STREAMS capsule has trailing data")
+	} else if err != io.EOF {
+		return 0, err
 	}
 	if maxStreams > maxStreamsLimit {
 		return 0, &http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: "WT_MAX_STREAMS value too large"}

--- a/capsule.go
+++ b/capsule.go
@@ -2,6 +2,7 @@ package webtransport
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"unicode/utf8"
 
@@ -9,53 +10,134 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
-const closeSessionCapsuleType http3.CapsuleType = 0x2843
+const (
+	closeSessionCapsuleType   http3.CapsuleType = 0x2843
+	maxStreamsBidiCapsuleType http3.CapsuleType = 0x190b4d3f
+	maxStreamsUniCapsuleType  http3.CapsuleType = 0x190b4d40
+)
 
 const maxCloseCapsuleErrorMsgLen = 1024
 
+const maxStreamsLimit = 1 << 60
+
+type capsule interface {
+	Append([]byte) []byte
+}
+
 // parseNextCapsule parses Capsules sent on the request stream.
-// It returns a SessionError when it receives a WT_CLOSE_SESSION Capsule.
-func parseNextCapsule(r io.Reader) error {
+// It returns the next known Capsule, skipping unknown Capsules.
+func parseNextCapsule(r io.Reader) (capsule, error) {
 	for {
 		typ, capsuleReader, err := http3.ParseCapsule(quicvarint.NewReader(r))
 		if err != nil {
-			return err
+			return nil, err
 		}
 		switch typ {
 		case closeSessionCapsuleType:
-			var b [4]byte
-			if _, err := io.ReadFull(capsuleReader, b[:]); err != nil {
-				return err
-			}
-			appErrCode := binary.BigEndian.Uint32(b[:])
-			// the length of the error message is limited to 1024 bytes
-			appErrMsg, err := io.ReadAll(io.LimitReader(capsuleReader, maxCloseCapsuleErrorMsgLen))
+			capsule, err := parseCloseSessionCapsule(capsuleReader)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			return &SessionError{
-				Remote:    true,
-				ErrorCode: SessionErrorCode(appErrCode),
-				Message:   string(appErrMsg),
+			return capsule, nil
+		case maxStreamsBidiCapsuleType:
+			maxStreams, err := parseMaxStreamsCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
 			}
+			return maxStreamsBidiCapsule{MaximumStreams: maxStreams}, nil
+		case maxStreamsUniCapsuleType:
+			maxStreams, err := parseMaxStreamsCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return maxStreamsUniCapsule{MaximumStreams: maxStreams}, nil
 		default:
 			// unknown capsule, skip it
 			if _, err := io.Copy(io.Discard, capsuleReader); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 }
 
-func appendCloseSessionCapsulePayload(b []byte, code SessionErrorCode, msg string) []byte {
+type closeSessionCapsule struct {
+	ErrorCode SessionErrorCode
+	Message   string
+}
+
+func parseCloseSessionCapsule(r io.Reader) (closeSessionCapsule, error) {
+	var b [4]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return closeSessionCapsule{}, err
+	}
+	msg, err := io.ReadAll(io.LimitReader(r, maxCloseCapsuleErrorMsgLen))
+	if err != nil {
+		return closeSessionCapsule{}, err
+	}
+	return closeSessionCapsule{
+		ErrorCode: SessionErrorCode(binary.BigEndian.Uint32(b[:])),
+		Message:   string(msg),
+	}, nil
+}
+
+func (c closeSessionCapsule) Append(b []byte) []byte {
+	msg := c.Message
 	if len(msg) > maxCloseCapsuleErrorMsgLen {
 		msg = truncateUTF8(msg, maxCloseCapsuleErrorMsgLen)
 	}
 
+	b = quicvarint.Append(b, uint64(closeSessionCapsuleType))
+	b = quicvarint.Append(b, uint64(4+len(msg)))
 	payloadStart := len(b)
 	b = append(b, 0, 0, 0, 0)
-	binary.BigEndian.PutUint32(b[payloadStart:], uint32(code))
+	binary.BigEndian.PutUint32(b[payloadStart:], uint32(c.ErrorCode))
 	return append(b, msg...)
+}
+
+func (c closeSessionCapsule) ToSessionError() *SessionError {
+	return &SessionError{
+		Remote:    true,
+		ErrorCode: c.ErrorCode,
+		Message:   c.Message,
+	}
+}
+
+type maxStreamsBidiCapsule struct {
+	MaximumStreams uint64
+}
+
+func (c maxStreamsBidiCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(maxStreamsBidiCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
+	return quicvarint.Append(b, c.MaximumStreams)
+}
+
+type maxStreamsUniCapsule struct {
+	MaximumStreams uint64
+}
+
+func (c maxStreamsUniCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(maxStreamsUniCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
+	return quicvarint.Append(b, c.MaximumStreams)
+}
+
+func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return 0, err
+	}
+	maxStreams, n, err := quicvarint.Parse(b)
+	if err != nil {
+		return 0, err
+	}
+	if n != len(b) {
+		return 0, errors.New("WT_MAX_STREAMS capsule has trailing data")
+	}
+	if maxStreams > maxStreamsLimit {
+		return 0, &http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: "WT_MAX_STREAMS value too large"}
+	}
+	return maxStreams, nil
 }
 
 // truncateUTF8 cuts a string to max n bytes without breaking UTF-8 characters.

--- a/capsule.go
+++ b/capsule.go
@@ -134,7 +134,7 @@ func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {
 		return 0, err
 	}
 	if maxStreams > maxStreamsLimit {
-		return 0, &http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: "WT_MAX_STREAMS value too large"}
+		return 0, errors.New("WT_MAX_STREAMS value too large")
 	}
 	return maxStreams, nil
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -3,6 +3,7 @@ package webtransport
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"strings"
 	"testing"
 
@@ -21,18 +22,25 @@ func TestParseCloseSessionCapsuleMessageTruncation(t *testing.T) {
 	var b bytes.Buffer
 	require.NoError(t, http3.WriteCapsule(quicvarint.NewWriter(&b), closeSessionCapsuleType, payload))
 
-	err := parseNextCapsule(&b)
-	var sessErr *SessionError
-	require.ErrorAs(t, err, &sessErr)
-	require.True(t, sessErr.Remote)
-	require.Equal(t, SessionErrorCode(1337), sessErr.ErrorCode)
-	require.Len(t, sessErr.Message, maxCloseCapsuleErrorMsgLen)
-	require.Equal(t, strings.Repeat("b", maxCloseCapsuleErrorMsgLen), sessErr.Message)
+	c, err := parseNextCapsule(&b)
+	require.NoError(t, err)
+	closeCapsule, ok := c.(closeSessionCapsule)
+	require.True(t, ok)
+	require.Equal(t, SessionErrorCode(1337), closeCapsule.ErrorCode)
+	require.Len(t, closeCapsule.Message, maxCloseCapsuleErrorMsgLen)
+	require.Equal(t, strings.Repeat("b", maxCloseCapsuleErrorMsgLen), closeCapsule.Message)
 }
 
-func TestAppendCloseSessionCapsulePayloadMessageTruncation(t *testing.T) {
-	payload := appendCloseSessionCapsulePayload(nil, 42, strings.Repeat("a", maxCloseCapsuleErrorMsgLen+500))
+func TestAppendCloseSessionCapsuleMessageTruncation(t *testing.T) {
+	var b bytes.Buffer
+	b.Write((closeSessionCapsule{ErrorCode: 42, Message: strings.Repeat("a", maxCloseCapsuleErrorMsgLen+500)}).Append(nil))
 
+	typ, r, err := http3.ParseCapsule(quicvarint.NewReader(&b))
+	require.NoError(t, err)
+	require.Equal(t, closeSessionCapsuleType, typ)
+
+	payload, err := io.ReadAll(r)
+	require.NoError(t, err)
 	require.Len(t, payload, 4+maxCloseCapsuleErrorMsgLen)
 	require.Equal(t, uint32(42), binary.BigEndian.Uint32(payload[:4]))
 	require.Equal(t, strings.Repeat("a", maxCloseCapsuleErrorMsgLen), string(payload[4:]))
@@ -40,15 +48,57 @@ func TestAppendCloseSessionCapsulePayloadMessageTruncation(t *testing.T) {
 
 func TestCloseSessionCapsuleRoundTrip(t *testing.T) {
 	var b bytes.Buffer
-	payload := appendCloseSessionCapsulePayload(nil, 42, "all good")
-	require.NoError(t, http3.WriteCapsule(quicvarint.NewWriter(&b), closeSessionCapsuleType, payload))
+	b.Write((closeSessionCapsule{ErrorCode: 42, Message: "all good"}).Append(nil))
 
-	err := parseNextCapsule(&b)
-	var sessErr *SessionError
-	require.ErrorAs(t, err, &sessErr)
-	require.True(t, sessErr.Remote)
-	require.Equal(t, SessionErrorCode(42), sessErr.ErrorCode)
-	require.Equal(t, "all good", sessErr.Message)
+	c, err := parseNextCapsule(&b)
+	require.NoError(t, err)
+	require.Equal(t, closeSessionCapsule{ErrorCode: 42, Message: "all good"}, c)
+}
+
+func TestMaxStreamsCapsuleRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    capsule
+		typ  http3.CapsuleType
+		max  uint64
+	}{
+		{
+			name: "bidirectional",
+			c:    maxStreamsBidiCapsule{MaximumStreams: 42},
+			typ:  maxStreamsBidiCapsuleType,
+			max:  42,
+		},
+		{
+			name: "unidirectional",
+			c:    maxStreamsUniCapsule{MaximumStreams: 1337},
+			typ:  maxStreamsUniCapsuleType,
+			max:  1337,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			b.Write(tc.c.Append(nil))
+
+			typ, r, err := http3.ParseCapsule(quicvarint.NewReader(&b))
+			require.NoError(t, err)
+			require.Equal(t, tc.typ, typ)
+			maxStreams, err := quicvarint.Read(quicvarint.NewReader(r))
+			require.NoError(t, err)
+			require.Equal(t, tc.max, maxStreams)
+
+			c, err := parseNextCapsule(bytes.NewReader(tc.c.Append(nil)))
+			require.NoError(t, err)
+			require.Equal(t, tc.c, c)
+		})
+	}
+}
+
+func TestParseMaxStreamsCapsuleTooLarge(t *testing.T) {
+	var b bytes.Buffer
+	b.Write((maxStreamsBidiCapsule{MaximumStreams: maxStreamsLimit + 1}).Append(nil))
+
+	_, err := parseNextCapsule(&b)
+	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
 }
 
 func TestTruncateUTF8(t *testing.T) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -98,7 +98,7 @@ func TestParseMaxStreamsCapsuleTooLarge(t *testing.T) {
 	b.Write((maxStreamsBidiCapsule{MaximumStreams: maxStreamsLimit + 1}).Append(nil))
 
 	_, err := parseNextCapsule(&b)
-	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
+	require.ErrorContains(t, err, "value too large")
 }
 
 func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -101,6 +101,16 @@ func TestParseMaxStreamsCapsuleTooLarge(t *testing.T) {
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
 }
 
+func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(maxStreamsBidiCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	_, err := parseNextCapsule(bytes.NewReader(b))
+	require.ErrorContains(t, err, "trailing data")
+}
+
 func TestTruncateUTF8(t *testing.T) {
 	input := "Go 🚀"
 	require.Len(t, input, 7)

--- a/session.go
+++ b/session.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-	"github.com/quic-go/quic-go/quicvarint"
 )
 
 // sessionID is the WebTransport Session ID
@@ -72,8 +71,20 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 }
 
 func (s *Session) handleConn() {
-	err := parseNextCapsule(s.str)
-	s.closeWithError(err)
+	for {
+		c, err := parseNextCapsule(s.str)
+		if err != nil {
+			s.closeWithError(err)
+			return
+		}
+		switch c := c.(type) {
+		case closeSessionCapsule:
+			s.closeWithError(c.ToSessionError())
+			return
+		case maxStreamsBidiCapsule, maxStreamsUniCapsule:
+			// TODO: handle max streams capsules
+		}
+	}
 }
 
 // addIncomingStream adds a bidirectional stream that the remote peer opened
@@ -183,8 +194,7 @@ func closeSessionStream(str http3Stream, code SessionErrorCode, msg string) erro
 	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
 	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
 	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
-	payload := appendCloseSessionCapsulePayload(nil, code, msg)
-	if err := http3.WriteCapsule(quicvarint.NewWriter(str), closeSessionCapsuleType, payload); err != nil {
+	if _, err := str.Write((closeSessionCapsule{ErrorCode: code, Message: msg}).Append(nil)); err != nil {
 		str.CancelWrite(WTSessionGoneErrorCode)
 	}
 


### PR DESCRIPTION
Needed for #291 and #292.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement parsing and serialization of WT_MAX_STREAMS capsules
> - Adds `maxStreamsBidiCapsule` and `maxStreamsUniCapsule` structs with `Append` methods that serialize WT_MAX_STREAMS capsules (type, length, varint payload) in [capsule.go](https://github.com/quic-go/webtransport-go/pull/293/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6).
> - Adds `parseMaxStreamsCapsule` helper that reads a QUIC varint, rejects trailing data, and enforces an upper bound (`maxStreamsLimit`).
> - Refactors `parseNextCapsule` to return a typed `capsule` interface instead of just an error, returning structured types for WT_CLOSE_SESSION and WT_MAX_STREAMS.
> - Refactors `closeSessionCapsule` into a struct with an `Append` method, replacing the former `appendCloseSessionCapsulePayload` utility.
> - Updates `Session.handleConn` in [session.go](https://github.com/quic-go/webtransport-go/pull/293/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) to loop on `parseNextCapsule`, handling close capsules and ignoring WT_MAX_STREAMS capsules (with a TODO for future handling).
> - Behavioral Change: `closeSessionStream` now writes the WT_CLOSE_SESSION frame via `closeSessionCapsule.Append` + `str.Write` instead of `http3.WriteCapsule`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 881206a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->