### PR TITLE
Send CONNECTION_CLOSE before tearing down the listener on Close() (0.11 regression)

### DIFF
--- a/server.go
+++ b/server.go
@@ -92,6 +92,7 @@ type Server struct {
 
 	connsMx sync.Mutex
 	conns   map[*quic.Conn]*sessionManager
+	closed  bool
 }
 
 func (s *Server) initialize() error {
@@ -150,8 +151,18 @@ func (s *Server) serve(conn net.PacketConn) error {
 		if err != nil {
 			return err
 		}
+
+		if s.isClosed() {
+			// Do not accept a new connection during shutdown
+			qconn.CloseWithError(0, "")
+			continue
+		}
+
 		s.refCount.Go(func() {
-			if err := s.ServeQUICConn(qconn); err != nil {
+			err := s.ServeQUICConn(qconn)
+			if errors.Is(err, context.Canceled) {
+				return
+			} else if err != nil {
 				log.Printf("http3: error serving QUIC connection: %v", err)
 			}
 		})
@@ -172,6 +183,14 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 	}
 
 	s.connsMx.Lock()
+
+	if s.closed {
+		// Shutting down, do not accept new connections
+		s.connsMx.Unlock()
+		conn.CloseWithError(0, "")
+		return context.Canceled
+	}
+
 	sessMgr, ok := s.conns[conn]
 	if !ok {
 		sessMgr = newSessionManager(s.timeout())
@@ -192,7 +211,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 		return err
 	}
 
-	// slose the connection when the server context is cancelled.
+	// Close the connection when the server context is cancelled.
 	go func() {
 		select {
 		case <-s.ctx.Done():
@@ -320,23 +339,39 @@ func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
 	return s.ListenAndServe()
 }
 
+func (s *Server) isClosed() bool {
+	s.connsMx.Lock()
+	defer s.connsMx.Unlock()
+
+	return s.closed
+}
+
 func (s *Server) Close() error {
 	// Make sure that ctxCancel is defined.
 	// This is expected to be uncommon.
 	// It only happens if the server is closed without Serve / ListenAndServe having been called.
 	s.initOnce.Do(func() {})
 
-	if s.ctxCancel != nil {
-		s.ctxCancel()
-	}
+	// Close the established connections first, while the listener's socket is still
+	// open, so each CONNECTION_CLOSE frame is actually transmitted to the peer.
+	// This must happen before canceling s.ctx: canceling it makes serve() return,
+	// and its deferred listener teardown closes the socket. If the socket is torn
+	// down first, the queued CONNECTION_CLOSE frames are never sent and the peers
+	// only learn the connections are gone at their idle timeout.
 	s.connsMx.Lock()
+	s.closed = true
 	if s.conns != nil {
-		for _, mgr := range s.conns {
+		for conn, mgr := range s.conns {
+			conn.CloseWithError(0, "")
 			mgr.Close()
 		}
 		s.conns = nil
 	}
 	s.connsMx.Unlock()
+
+	if s.ctxCancel != nil {
+		s.ctxCancel()
+	}
 
 	err := s.H3.Close()
 	s.refCount.Wait()

--- a/server.go
+++ b/server.go
@@ -347,10 +347,11 @@ func (s *Server) isClosed() bool {
 }
 
 func (s *Server) Close() error {
-	// Make sure that ctxCancel is defined.
-	// This is expected to be uncommon.
-	// It only happens if the server is closed without Serve / ListenAndServe having been called.
-	s.initOnce.Do(func() {})
+	// Ensure the server is initialized so s.ctx and s.ctxCancel are defined before they are used below.
+	// This covers Close being called without Serve/ListenAndServe, and also Close racing ListenAndServe's
+	// initialize(): firing the Once with an empty function (as this previously did) would mark initialization
+	// "done" without running init(), leaving s.ctx nil and crashing serve()'s ln.Accept(s.ctx).
+	_ = s.initialize()
 
 	// Close the established connections first, while the listener's socket is still
 	// open, so each CONNECTION_CLOSE frame is actually transmitted to the peer.

--- a/server.go
+++ b/server.go
@@ -347,18 +347,10 @@ func (s *Server) isClosed() bool {
 }
 
 func (s *Server) Close() error {
-	// Ensure the server is initialized so s.ctx and s.ctxCancel are defined before they are used below.
-	// This covers Close being called without Serve/ListenAndServe, and also Close racing ListenAndServe's
-	// initialize(): firing the Once with an empty function (as this previously did) would mark initialization
-	// "done" without running init(), leaving s.ctx nil and crashing serve()'s ln.Accept(s.ctx).
 	_ = s.initialize()
 
 	// Close the established connections first, while the listener's socket is still
 	// open, so each CONNECTION_CLOSE frame is actually transmitted to the peer.
-	// This must happen before canceling s.ctx: canceling it makes serve() return,
-	// and its deferred listener teardown closes the socket. If the socket is torn
-	// down first, the queued CONNECTION_CLOSE frames are never sent and the peers
-	// only learn the connections are gone at their idle timeout.
 	s.connsMx.Lock()
 	s.closed = true
 	if s.conns != nil {

--- a/server.go
+++ b/server.go
@@ -160,7 +160,7 @@ func (s *Server) serve(conn net.PacketConn) error {
 
 		s.refCount.Go(func() {
 			err := s.ServeQUICConn(qconn)
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, http.ErrServerClosed) {
 				return
 			} else if err != nil {
 				log.Printf("http3: error serving QUIC connection: %v", err)
@@ -188,7 +188,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 		// Shutting down, do not accept new connections
 		s.connsMx.Unlock()
 		conn.CloseWithError(0, "")
-		return context.Canceled
+		return http.ErrServerClosed
 	}
 
 	sessMgr, ok := s.conns[conn]

--- a/session_test.go
+++ b/session_test.go
@@ -100,6 +100,22 @@ func newConnPair(t *testing.T, clientConn, serverConn net.PacketConn) (client, s
 	return cl, conn
 }
 
+func TestServerRejectsQUICConnAfterClose(t *testing.T) {
+	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+
+	s := Server{H3: &http3.Server{TLSConfig: TLSConf}}
+	require.NoError(t, s.initialize())
+	require.NoError(t, s.Close())
+
+	require.ErrorIs(t, s.ServeQUICConn(serverConn), context.Canceled)
+	select {
+	case <-clientConn.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for connection to close")
+	}
+	require.Nil(t, s.conns)
+}
+
 // TestCloseWithErrorTruncatesSendMessage tests that when CloseWithError is called
 // with a message longer than 1024 bytes, the capsule written to the wire contains
 // a truncated message.

--- a/session_test.go
+++ b/session_test.go
@@ -118,7 +118,7 @@ func TestServerRejectsQUICConnAfterClose(t *testing.T) {
 	require.NoError(t, s.initialize())
 	require.NoError(t, s.Close())
 
-	require.ErrorIs(t, s.ServeQUICConn(serverConn), context.Canceled)
+	require.ErrorIs(t, s.ServeQUICConn(serverConn), http.ErrServerClosed)
 	select {
 	case <-clientConn.Context().Done():
 	case <-time.After(time.Second):


### PR DESCRIPTION
Split from #288 as requested

Server.Close() canceled the server context (s.ctx) before closing the established connections.
Canceling the context makes serve() return, and its deferred listener teardown closes the underlying socket.

The per-connection shutdown is handled asynchronously by a watcher goroutine that calls conn.CloseWithError when s.ctx is done, so it raced the socket teardown: when the socket was closed first, the queued CONNECTION_CLOSE frames were never transmitted, and peers only learned their connections were gone at the idle timeout (tens of seconds later).

No test here, as this is something challenging to validate with a unit test.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send CONNECTION_CLOSE to active QUIC connections before tearing down the HTTP/3 server on `Close()`
> - `Server.Close()` now sets a `closed` flag and sends `CloseWithError(0, "")` to all active QUIC connections before canceling the server context, fixing a 0.11 regression where connections were torn down without a proper CONNECTION_CLOSE frame.
> - `Server.ServeQUICConn()` checks the `closed` flag under lock and immediately closes any newly passed connection with `http.ErrServerClosed` if the server is shutting down.
> - The `serve` loop also guards against newly accepted connections arriving after `Close()` is called, closing them immediately rather than handing them to `ServeQUICConn`.
> - A new test (`TestServerRejectsQUICConnAfterClose`) verifies that `ServeQUICConn` returns `http.ErrServerClosed` and the client connection is closed after `Close()` is called.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c199376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->