### PR TITLE
fix missing context cancelation in Session.Open{Uni}StreamSync

### DIFF
--- a/session.go
+++ b/session.go
@@ -274,6 +274,7 @@ func (s *Session) OpenStreamSync(ctx context.Context) (*Stream, error) {
 		return nil, s.closeErr
 	}
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	id := s.addStreamCtxCancel(cancel)
 	s.closeMx.Unlock()
 
@@ -320,6 +321,7 @@ func (s *Session) OpenUniStreamSync(ctx context.Context) (str *SendStream, err e
 		return nil, s.closeErr
 	}
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	id := s.addStreamCtxCancel(cancel)
 	s.closeMx.Unlock()
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix missing context cancellation in `Session.OpenStreamSync` and `Session.OpenUniStreamSync`
Adds a deferred `cancel()` call immediately after `context.WithCancel(ctx)` in both `OpenStreamSync` and `OpenUniStreamSync` in [session.go](https://github.com/quic-go/webtransport-go/pull/297/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac). Without this, the child context was never cancelled on return, leaking resources until the parent context was cancelled.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7946dd.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->