### PR TITLE
implement handling of the peer’s stream limit

### DIFF
--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -3,11 +3,29 @@ package webtransport
 import (
 	"context"
 	"math/rand/v2"
+	"slices"
 	"sync"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/quicvarint"
 )
+
+// StreamLimitReachedError is returned from OpenStream and OpenUniStream
+// when it is not possible to open a new stream because the peer's stream limit is reached.
+type StreamLimitReachedError struct{}
+
+func (e StreamLimitReachedError) Error() string { return "too many open streams" }
+
+const maxOutgoingStreams = 1 << 60
+
+// outgoingStreamLimit tracks the number of WebTransport streams opened against
+// the peer's advertised stream limit.
+type outgoingStreamLimit struct {
+	OpenQueue []chan struct{}
+
+	NumStreams uint64 // total number of streams opened for this session
+	MaxStreams uint64 // stream limit, as advertised by the peer
+}
 
 type outgoingStreamsMap struct {
 	conn         *quic.Conn
@@ -17,6 +35,8 @@ type outgoingStreamsMap struct {
 	mx         sync.Mutex
 	closeErr   error
 	streamCtxs map[int]context.CancelFunc
+	bidiLimit  outgoingStreamLimit
+	uniLimit   outgoingStreamLimit
 	m          map[quic.StreamID]func(error)
 }
 
@@ -34,6 +54,8 @@ func newOutgoingStreamsMap(conn *quic.Conn, sessionID sessionID) *outgoingStream
 		streamHdr:    streamHdr,
 		uniStreamHdr: uniStreamHdr,
 		streamCtxs:   make(map[int]context.CancelFunc),
+		bidiLimit:    outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
+		uniLimit:     outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
 		m:            make(map[quic.StreamID]func(error)),
 	}
 }
@@ -63,9 +85,16 @@ func (s *outgoingStreamsMap) OpenStream() (*Stream, error) {
 	if s.closeErr != nil {
 		return nil, s.closeErr
 	}
+	// if there are OpenStreamSync calls waiting, return an error here
+	if len(s.bidiLimit.OpenQueue) > 0 || s.bidiLimit.NumStreams >= s.bidiLimit.MaxStreams {
+		return nil, &StreamLimitReachedError{}
+	}
+	s.bidiLimit.NumStreams++
 
 	qstr, err := s.conn.OpenStream()
 	if err != nil {
+		s.bidiLimit.NumStreams--
+		s.maybeUnblockOpenSync(&s.bidiLimit)
 		return nil, err
 	}
 	return s.addStream(qstr), nil
@@ -87,6 +116,10 @@ func (s *outgoingStreamsMap) OpenStreamSync(ctx context.Context) (*Stream, error
 		s.mx.Unlock()
 		return nil, s.closeErr
 	}
+	if err := s.waitForStreamLimit(ctx, &s.bidiLimit); err != nil {
+		s.mx.Unlock()
+		return nil, err
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	id := s.addStreamCtxCancel(cancel)
@@ -104,6 +137,10 @@ func (s *outgoingStreamsMap) OpenStreamSync(ctx context.Context) (*Stream, error
 		return nil, s.closeErr
 	}
 	if err != nil {
+		if qstr == nil && s.closeErr == nil {
+			s.bidiLimit.NumStreams--
+			s.maybeUnblockOpenSync(&s.bidiLimit)
+		}
 		if s.closeErr != nil {
 			return nil, s.closeErr
 		}
@@ -119,8 +156,15 @@ func (s *outgoingStreamsMap) OpenUniStream() (*SendStream, error) {
 	if s.closeErr != nil {
 		return nil, s.closeErr
 	}
+	// if there are OpenUniStreamSync calls waiting, return an error here
+	if len(s.uniLimit.OpenQueue) > 0 || s.uniLimit.NumStreams >= s.uniLimit.MaxStreams {
+		return nil, &StreamLimitReachedError{}
+	}
+	s.uniLimit.NumStreams++
 	qstr, err := s.conn.OpenUniStream()
 	if err != nil {
+		s.uniLimit.NumStreams--
+		s.maybeUnblockOpenSync(&s.uniLimit)
 		return nil, err
 	}
 	return s.addSendStream(qstr), nil
@@ -131,6 +175,10 @@ func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendSt
 	if s.closeErr != nil {
 		s.mx.Unlock()
 		return nil, s.closeErr
+	}
+	if err := s.waitForStreamLimit(ctx, &s.uniLimit); err != nil {
+		s.mx.Unlock()
+		return nil, err
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -148,12 +196,100 @@ func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendSt
 		return nil, s.closeErr
 	}
 	if err != nil {
+		if qstr == nil && s.closeErr == nil {
+			s.uniLimit.NumStreams--
+			s.maybeUnblockOpenSync(&s.uniLimit)
+		}
 		if s.closeErr != nil {
 			return nil, s.closeErr
 		}
 		return nil, err
 	}
 	return s.addSendStream(qstr), nil
+}
+
+func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit *outgoingStreamLimit) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(streamLimit.OpenQueue) == 0 && streamLimit.NumStreams < streamLimit.MaxStreams {
+		streamLimit.NumStreams++
+		return nil
+	}
+
+	waitChan := make(chan struct{}, 1)
+	streamLimit.OpenQueue = append(streamLimit.OpenQueue, waitChan)
+
+	for {
+		s.mx.Unlock()
+		select {
+		case <-ctx.Done():
+			s.mx.Lock()
+			streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+				return c == waitChan
+			})
+			// If we just received a WT_MAX_STREAMS capsule, this might have been the next stream
+			// that could be opened. Make sure we unblock the next OpenStreamSync call.
+			s.maybeUnblockOpenSync(streamLimit)
+			return ctx.Err()
+		case <-waitChan:
+		}
+
+		s.mx.Lock()
+		if s.closeErr != nil {
+			return s.closeErr
+		}
+		if err := ctx.Err(); err != nil {
+			streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+				return c == waitChan
+			})
+			s.maybeUnblockOpenSync(streamLimit)
+			return err
+		}
+		if streamLimit.NumStreams >= streamLimit.MaxStreams {
+			// no stream available. Continue waiting.
+			continue
+		}
+		streamLimit.NumStreams++
+		streamLimit.OpenQueue = streamLimit.OpenQueue[1:]
+		s.maybeUnblockOpenSync(streamLimit)
+		return nil
+	}
+}
+
+func (s *outgoingStreamsMap) UpdateBidiStreamLimit(limit uint64) {
+	s.updateStreamLimit(&s.bidiLimit, limit)
+}
+
+func (s *outgoingStreamsMap) UpdateUniStreamLimit(limit uint64) {
+	s.updateStreamLimit(&s.uniLimit, limit)
+}
+
+func (s *outgoingStreamsMap) updateStreamLimit(streamLimit *outgoingStreamLimit, limit uint64) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if limit <= streamLimit.MaxStreams || s.closeErr != nil {
+		return
+	}
+	streamLimit.MaxStreams = limit
+	s.maybeUnblockOpenSync(streamLimit)
+}
+
+// unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream.
+func (s *outgoingStreamsMap) maybeUnblockOpenSync(streamLimit *outgoingStreamLimit) {
+	if len(streamLimit.OpenQueue) == 0 {
+		return
+	}
+	if streamLimit.NumStreams >= streamLimit.MaxStreams {
+		return
+	}
+	// maybeUnblockOpenSync is called both from OpenStreamSync and from UpdateStreamLimit.
+	// It's sufficient to only unblock OpenStreamSync once.
+	select {
+	case streamLimit.OpenQueue[0] <- struct{}{}:
+	default:
+	}
 }
 
 func (s *outgoingStreamsMap) CloseSession(err error) {
@@ -168,6 +304,14 @@ func (s *outgoingStreamsMap) CloseSession(err error) {
 	for _, cancel := range s.streamCtxs {
 		cancel()
 	}
+	for _, c := range s.bidiLimit.OpenQueue {
+		close(c)
+	}
+	s.bidiLimit.OpenQueue = nil
+	for _, c := range s.uniLimit.OpenQueue {
+		close(c)
+	}
+	s.uniLimit.OpenQueue = nil
 
 	for _, cl := range s.m {
 		cl(err)

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -54,3 +54,120 @@ func testOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T, openStream, 
 		t.Fatal("timeout")
 	}
 }
+
+func TestOutgoingStreamsMapOpenStreamLimit(t *testing.T) {
+	t.Run("bidirectional", func(t *testing.T) {
+		streams := newOutgoingStreamsMap(nil, 42)
+		streams.bidiLimit.MaxStreams = 0
+		_, err := streams.OpenStream()
+		var limitErr *StreamLimitReachedError
+		require.ErrorAs(t, err, &limitErr)
+	})
+
+	t.Run("unidirectional", func(t *testing.T) {
+		streams := newOutgoingStreamsMap(nil, 42)
+		streams.uniLimit.MaxStreams = 0
+		_, err := streams.OpenUniStream()
+		var limitErr *StreamLimitReachedError
+		require.ErrorAs(t, err, &limitErr)
+	})
+}
+
+func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
+	t.Run("bidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
+			t,
+			func(m *outgoingStreamsMap) error { _, err := m.OpenStream(); return err },
+			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenStreamSync(ctx); return err },
+			(*outgoingStreamsMap).UpdateBidiStreamLimit,
+		)
+	})
+
+	t.Run("unidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
+			t,
+			func(m *outgoingStreamsMap) error { _, err := m.OpenUniStream(); return err },
+			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenUniStreamSync(ctx); return err },
+			(*outgoingStreamsMap).UpdateUniStreamLimit,
+		)
+	})
+}
+
+func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
+	t *testing.T,
+	openStream func(*outgoingStreamsMap) error,
+	openStreamSync func(*outgoingStreamsMap, context.Context) error,
+	updateLimit func(*outgoingStreamsMap, uint64),
+) {
+	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+	streams := newOutgoingStreamsMap(clientConn, 42)
+	streams.bidiLimit.MaxStreams = 0
+	streams.uniLimit.MaxStreams = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- openStreamSync(streams, ctx) }()
+
+	select {
+	case <-errChan:
+		t.Fatal("should not have opened stream")
+	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	}
+
+	updateLimit(streams, 1)
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	err := openStream(streams)
+	var limitErr *StreamLimitReachedError
+	require.ErrorAs(t, err, &limitErr)
+
+	go func() { errChan <- openStreamSync(streams, ctx) }()
+	select {
+	case <-errChan:
+		t.Fatal("should not have opened stream")
+	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	}
+}
+
+func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
+	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+	streams := newOutgoingStreamsMap(clientConn, 42)
+	streams.bidiLimit.MaxStreams = 0
+
+	const numStreams = 16
+	type result struct {
+		index int
+		err   error
+	}
+	resultChan := make(chan result, numStreams)
+	for i := range numStreams {
+		go func() {
+			_, err := streams.OpenStreamSync(context.Background())
+			resultChan <- result{index: i, err: err}
+		}()
+		require.Eventually(t, func() bool {
+			streams.mx.Lock()
+			defer streams.mx.Unlock()
+			return len(streams.bidiLimit.OpenQueue) == i+1
+		}, time.Second, scaleDuration(time.Millisecond))
+	}
+
+	for i := range numStreams {
+		streams.UpdateBidiStreamLimit(uint64(i + 1))
+		select {
+		case r := <-resultChan:
+			require.NoError(t, r.err)
+			require.Equal(t, i, r.index)
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+	}
+}


### PR DESCRIPTION
This pull request only implements the stream limit handling on the streams map. It does not yet wire this up into the session since negotiation of flow control and handling of the SETTINGS values will take some more care.

The logic here closely mirrors what quic-go does in its streams map.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce peer stream limits in outgoing streams map with FIFO blocking
> - Adds `StreamLimitReachedError` returned by `OpenStream`/`OpenUniStream` when the peer's stream limit is reached or sync waiters are queued.
> - `OpenStreamSync`/`OpenUniStreamSync` now block until stream credit is available, using a FIFO queue to order waiting callers fairly.
> - Adds `UpdateBidiStreamLimit`/`UpdateUniStreamLimit` methods to increase limits and unblock the next waiter when credit becomes available.
> - `CloseSession` wakes all blocked `Open*StreamSync` callers so they return promptly with the session error.
> - Behavioral Change: `OpenStream`/`OpenUniStream` now return a typed error instead of succeeding when the peer's limit is 0 or sync waiters are pending.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54b435a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->