### PR TITLE
use H3_DATAGRAM_ERROR when parsing a capsule fails

### DIFF
--- a/session.go
+++ b/session.go
@@ -74,7 +74,7 @@ func (s *Session) handleConn() {
 	for {
 		c, err := parseNextCapsule(s.str)
 		if err != nil {
-			s.closeWithError(err)
+			s.closeWithError(&http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: err.Error()})
 			return
 		}
 		switch c := c.(type) {

--- a/session_test.go
+++ b/session_test.go
@@ -1,6 +1,7 @@
 package webtransport
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
@@ -20,6 +21,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type mockHTTP3Stream struct{ *bytes.Reader }
+
+func (s mockHTTP3Stream) Write(p []byte) (int, error)                     { return len(p), nil }
+func (s mockHTTP3Stream) Close() error                                    { return nil }
+func (s mockHTTP3Stream) ReceiveDatagram(context.Context) ([]byte, error) { return nil, io.EOF }
+func (s mockHTTP3Stream) SendDatagram([]byte) error                       { return nil }
+func (s mockHTTP3Stream) CancelRead(quic.StreamErrorCode)                 {}
+func (s mockHTTP3Stream) CancelWrite(quic.StreamErrorCode)                {}
+func (s mockHTTP3Stream) SetWriteDeadline(time.Time) error                { return nil }
 
 func scaleDuration(d time.Duration) time.Duration {
 	if os.Getenv("CI") != "" {
@@ -157,4 +168,25 @@ func TestCloseWithErrorTruncatesSendMessage(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for capsule")
 	}
+}
+
+func TestCapsuleParseErrorClosesSessionWithDatagramError(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(maxStreamsBidiCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+	select {
+	case <-sess.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	sess.closeMx.Lock()
+	err := sess.closeErr
+	sess.closeMx.Unlock()
+
+	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
+	require.ErrorContains(t, err, "trailing data")
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Use `H3_DATAGRAM_ERROR` when closing a WebTransport session on capsule parse failure
Previously, capsule parse errors in `Session.handleConn` were passed directly to `closeWithError` as generic errors. Now, the session closes with an `http3.Error` carrying `ErrCodeDatagramError` and the original error message, matching the H3 spec. A new test in [session_test.go](https://github.com/quic-go/webtransport-go/pull/299/files#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557) verifies this behavior by crafting a malformed capsule and asserting the close error is an `http3.Error` with `ErrCodeDatagramError`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10f51a5.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->