### PR TITLE
implement parsing and serialization of WT_STREAMS_BLOCKED capsule

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	closeSessionCapsuleType   http3.CapsuleType = 0x2843
-	maxStreamsBidiCapsuleType http3.CapsuleType = 0x190b4d3f
-	maxStreamsUniCapsuleType  http3.CapsuleType = 0x190b4d40
+	closeSessionCapsuleType       http3.CapsuleType = 0x2843
+	maxStreamsBidiCapsuleType     http3.CapsuleType = 0x190b4d3f
+	maxStreamsUniCapsuleType      http3.CapsuleType = 0x190b4d40
+	streamsBlockedBidiCapsuleType http3.CapsuleType = 0x190b4d43
+	streamsBlockedUniCapsuleType  http3.CapsuleType = 0x190b4d44
 )
 
 const maxCloseCapsuleErrorMsgLen = 1024
@@ -51,6 +53,18 @@ func parseNextCapsule(r io.Reader) (capsule, error) {
 				return nil, err
 			}
 			return maxStreamsUniCapsule{MaximumStreams: maxStreams}, nil
+		case streamsBlockedBidiCapsuleType:
+			maxStreams, err := parseStreamsBlockedCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return streamsBlockedBidiCapsule{MaximumStreams: maxStreams}, nil
+		case streamsBlockedUniCapsuleType:
+			maxStreams, err := parseStreamsBlockedCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return streamsBlockedUniCapsule{MaximumStreams: maxStreams}, nil
 		default:
 			// unknown capsule, skip it
 			if _, err := io.Copy(io.Discard, capsuleReader); err != nil {
@@ -122,6 +136,26 @@ func (c maxStreamsUniCapsule) Append(b []byte) []byte {
 	return quicvarint.Append(b, c.MaximumStreams)
 }
 
+type streamsBlockedBidiCapsule struct {
+	MaximumStreams uint64
+}
+
+func (c streamsBlockedBidiCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(streamsBlockedBidiCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
+	return quicvarint.Append(b, c.MaximumStreams)
+}
+
+type streamsBlockedUniCapsule struct {
+	MaximumStreams uint64
+}
+
+func (c streamsBlockedUniCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(streamsBlockedUniCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
+	return quicvarint.Append(b, c.MaximumStreams)
+}
+
 func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {
 	maxStreams, err := quicvarint.Read(quicvarint.NewReader(r))
 	if err != nil {
@@ -135,6 +169,23 @@ func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {
 	}
 	if maxStreams > maxStreamsLimit {
 		return 0, errors.New("WT_MAX_STREAMS value too large")
+	}
+	return maxStreams, nil
+}
+
+func parseStreamsBlockedCapsule(r io.Reader) (uint64, error) {
+	maxStreams, err := quicvarint.Read(quicvarint.NewReader(r))
+	if err != nil {
+		return 0, err
+	}
+	var extra [1]byte
+	if _, err := io.ReadFull(r, extra[:]); err == nil {
+		return 0, errors.New("WT_STREAMS_BLOCKED capsule has trailing data")
+	} else if err != io.EOF {
+		return 0, err
+	}
+	if maxStreams > maxStreamsLimit {
+		return 0, errors.New("WT_STREAMS_BLOCKED value too large")
 	}
 	return maxStreams, nil
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -93,12 +93,58 @@ func TestMaxStreamsCapsuleRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStreamsBlockedCapsuleRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    capsule
+		typ  http3.CapsuleType
+		max  uint64
+	}{
+		{
+			name: "bidirectional",
+			c:    streamsBlockedBidiCapsule{MaximumStreams: 42},
+			typ:  streamsBlockedBidiCapsuleType,
+			max:  42,
+		},
+		{
+			name: "unidirectional",
+			c:    streamsBlockedUniCapsule{MaximumStreams: 1337},
+			typ:  streamsBlockedUniCapsuleType,
+			max:  1337,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			b.Write(tc.c.Append(nil))
+
+			typ, r, err := http3.ParseCapsule(quicvarint.NewReader(&b))
+			require.NoError(t, err)
+			require.Equal(t, tc.typ, typ)
+			maxStreams, err := quicvarint.Read(quicvarint.NewReader(r))
+			require.NoError(t, err)
+			require.Equal(t, tc.max, maxStreams)
+
+			c, err := parseNextCapsule(bytes.NewReader(tc.c.Append(nil)))
+			require.NoError(t, err)
+			require.Equal(t, tc.c, c)
+		})
+	}
+}
+
 func TestParseMaxStreamsCapsuleTooLarge(t *testing.T) {
 	var b bytes.Buffer
 	b.Write((maxStreamsBidiCapsule{MaximumStreams: maxStreamsLimit + 1}).Append(nil))
 
 	_, err := parseNextCapsule(&b)
 	require.ErrorContains(t, err, "value too large")
+}
+
+func TestParseStreamsBlockedCapsuleTooLarge(t *testing.T) {
+	var b bytes.Buffer
+	b.Write((streamsBlockedBidiCapsule{MaximumStreams: maxStreamsLimit + 1}).Append(nil))
+
+	_, err := parseNextCapsule(&b)
+	require.ErrorContains(t, err, "WT_STREAMS_BLOCKED value too large")
 }
 
 func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {
@@ -109,6 +155,16 @@ func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {
 
 	_, err := parseNextCapsule(bytes.NewReader(b))
 	require.ErrorContains(t, err, "trailing data")
+}
+
+func TestParseStreamsBlockedCapsuleTrailingData(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(streamsBlockedUniCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	_, err := parseNextCapsule(bytes.NewReader(b))
+	require.ErrorContains(t, err, "WT_STREAMS_BLOCKED capsule has trailing data")
 }
 
 func TestTruncateUTF8(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -83,6 +83,8 @@ func (s *Session) handleConn() {
 			return
 		case maxStreamsBidiCapsule, maxStreamsUniCapsule:
 			// TODO: handle max streams capsules
+		case streamsBlockedBidiCapsule, streamsBlockedUniCapsule:
+			// TODO: log blocked capsules
 		}
 	}
 }


### PR DESCRIPTION
For #296.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add parsing and serialization of `WT_STREAMS_BLOCKED` capsules
> - Adds `streamsBlockedBidiCapsule` and `streamsBlockedUniCapsule` structs with `Append` methods that serialize using `quicvarint` encoding in [capsule.go](https://github.com/quic-go/webtransport-go/pull/300/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6).
> - Extends `parseNextCapsule` to recognize and parse both new capsule types instead of skipping them; validates payload size, rejects trailing data, and enforces `maxStreamsLimit`.
> - Adds a stub case in `Session.handleConn` in [session.go](https://github.com/quic-go/webtransport-go/pull/300/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) to match and ignore these capsules for now (marked TODO).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c894ff7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->