### PR TITLE
implement capsule sending logic in the session

### DIFF
--- a/client.go
+++ b/client.go
@@ -269,7 +269,10 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 		protocol, err = d.negotiateProtocol(protocolHeader)
 		if err != nil {
 			sessErr := &SessionError{ErrorCode: WTALPNErrorCode, Message: err.Error()}
-			_ = closeSessionStream(requestStr, sessErr.ErrorCode, sessErr.Message)
+			_ = closeSessionStream(
+				requestStr,
+				closeSessionCapsule{ErrorCode: sessErr.ErrorCode, Message: sessErr.Message},
+			)
 			return rsp, nil, sessErr
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -50,6 +50,7 @@ type Session struct {
 
 	capsuleQueueMx      sync.Mutex
 	capsuleQueue        []capsule
+	pendingCloseCapsule *closeSessionCapsule
 	capsuleQueueUpdated chan struct{}
 
 	incomingStreams incomingStreamsMap
@@ -119,6 +120,12 @@ func (s *Session) writeToConnectStream() {
 
 		for {
 			s.capsuleQueueMx.Lock()
+			if s.pendingCloseCapsule != nil {
+				closeCapsule := *s.pendingCloseCapsule
+				s.capsuleQueueMx.Unlock()
+				_ = closeSessionStream(s.str, closeCapsule)
+				return
+			}
 			if len(s.capsuleQueue) == 0 {
 				s.capsuleQueueMx.Unlock()
 				break
@@ -126,34 +133,26 @@ func (s *Session) writeToConnectStream() {
 			c := s.capsuleQueue[0]
 			s.capsuleQueueMx.Unlock()
 
-			if closeCapsule, ok := c.(closeSessionCapsule); ok {
-				_ = closeSessionStream(s.str, closeCapsule)
-				return
-			}
 			n, err := s.str.Write(c.Append(nil))
 			if err != nil {
-				s.capsuleQueueMx.Lock()
-				closing := false
-				if len(s.capsuleQueue) > 0 {
-					_, closing = s.capsuleQueue[0].(closeSessionCapsule)
-				}
-				s.capsuleQueueMx.Unlock()
-				if closing {
-					if n > 0 {
-						s.str.CancelRead(WTSessionGoneErrorCode)
-						s.str.CancelWrite(WTSessionGoneErrorCode)
-						return
+				if !s.closeWithError(err, nil) {
+					s.capsuleQueueMx.Lock()
+					hasClose := s.pendingCloseCapsule != nil
+					s.capsuleQueueMx.Unlock()
+					if hasClose {
+						if n > 0 {
+							s.str.CancelRead(WTSessionGoneErrorCode)
+							s.str.CancelWrite(WTSessionGoneErrorCode)
+							return
+						}
+						continue
 					}
-					continue
 				}
-				s.closeWithError(err, nil)
 				return
 			}
 			s.capsuleQueueMx.Lock()
 			if len(s.capsuleQueue) > 0 {
-				if _, closing := s.capsuleQueue[0].(closeSessionCapsule); !closing {
-					s.capsuleQueue = s.capsuleQueue[1:]
-				}
+				s.capsuleQueue = s.capsuleQueue[1:]
 			}
 			s.capsuleQueueMx.Unlock()
 		}
@@ -320,7 +319,8 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 
 	if closeCapsule != nil {
 		s.capsuleQueueMx.Lock()
-		s.capsuleQueue = []capsule{*closeCapsule}
+		s.capsuleQueue = nil
+		s.pendingCloseCapsule = closeCapsule
 		s.capsuleQueueMx.Unlock()
 
 		s.str.SetWriteDeadline(time.Now().Add(closeSessionTimeout))
@@ -330,6 +330,11 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 		}
 		return true
 	}
+
+	s.capsuleQueueMx.Lock()
+	s.capsuleQueue = nil
+	s.pendingCloseCapsule = nil
+	s.capsuleQueueMx.Unlock()
 
 	code := WTSessionGoneErrorCode
 	var h3Err *http3.Error

--- a/session.go
+++ b/session.go
@@ -2,6 +2,7 @@ package webtransport
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -47,9 +48,18 @@ type Session struct {
 	closeMx  sync.Mutex
 	closeErr error // not nil once the session is closed
 
+	capsuleQueueMx      sync.Mutex
+	capsuleQueue        []capsule
+	capsuleQueueUpdated chan struct{}
+
 	incomingStreams incomingStreamsMap
 	outgoingStreams outgoingStreamsMap
 }
+
+// Capsule writes can block if the peer withholds CONNECT stream flow control credit.
+// We bound the queue to avoid unbounded memory growth.
+// 4096 should be more than enough slack for normal loss/reordering.
+const maxQueuedOutgoingCapsules = 4096
 
 func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str http3Stream, applicationProtocol string) *Session {
 	ctx, ctxCancel := context.WithCancel(ctx)
@@ -59,33 +69,91 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		str:                 str,
 		applicationProtocol: applicationProtocol,
 		ctx:                 ctx,
+		capsuleQueueUpdated: make(chan struct{}, 1),
 		incomingStreams:     *newIncomingStreamsMap(ctx),
-		outgoingStreams:     *newOutgoingStreamsMap(conn, sessionID),
 	}
+	c.outgoingStreams = *newOutgoingStreamsMap(conn, sessionID)
 
 	go func() {
 		defer ctxCancel()
-		c.handleConn()
+		c.readFromConnectStream()
+	}()
+	go func() {
+		defer ctxCancel()
+		c.writeToConnectStream()
 	}()
 	return c
 }
 
-func (s *Session) handleConn() {
+func (s *Session) readFromConnectStream() {
 	for {
 		c, err := parseNextCapsule(s.str)
 		if err != nil {
-			s.closeWithError(&http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: err.Error()})
+			s.closeWithError(&http3.Error{ErrorCode: http3.ErrCodeDatagramError, ErrorMessage: err.Error()}, nil)
 			return
 		}
 		switch c := c.(type) {
 		case closeSessionCapsule:
-			s.closeWithError(c.ToSessionError())
+			s.closeWithError(c.ToSessionError(), nil)
 			return
 		case maxStreamsBidiCapsule, maxStreamsUniCapsule:
 			// TODO: handle max streams capsules
 		case streamsBlockedBidiCapsule, streamsBlockedUniCapsule:
 			// TODO: log blocked capsules
 		}
+	}
+}
+
+func (s *Session) writeToConnectStream() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-s.capsuleQueueUpdated:
+		}
+
+		for {
+			s.capsuleQueueMx.Lock()
+			if len(s.capsuleQueue) == 0 {
+				s.capsuleQueueMx.Unlock()
+				break
+			}
+			c := s.capsuleQueue[0]
+			s.capsuleQueueMx.Unlock()
+
+			if _, err := s.str.Write(c.Append(nil)); err != nil {
+				s.closeWithError(err, nil)
+				return
+			}
+			s.capsuleQueueMx.Lock()
+			s.capsuleQueue = s.capsuleQueue[1:]
+			s.capsuleQueueMx.Unlock()
+		}
+	}
+}
+
+func (s *Session) queueCapsule(c capsule) {
+	select {
+	case <-s.ctx.Done():
+		return
+	default:
+	}
+
+	s.capsuleQueueMx.Lock()
+	if len(s.capsuleQueue) >= maxQueuedOutgoingCapsules {
+		s.capsuleQueueMx.Unlock()
+		s.closeWithError(&http3.Error{
+			ErrorCode:    http3.ErrCodeExcessiveLoad,
+			ErrorMessage: "webtransport: outgoing capsule queue full",
+		}, nil)
+		return
+	}
+	s.capsuleQueue = append(s.capsuleQueue, c)
+	s.capsuleQueueMx.Unlock()
+
+	select {
+	case s.capsuleQueueUpdated <- struct{}{}:
+	default:
 	}
 }
 
@@ -181,22 +249,22 @@ func (s *Session) RemoteAddr() net.Addr {
 }
 
 func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
-	first, err := s.closeWithError(&SessionError{ErrorCode: code, Message: msg})
-	if err != nil || !first {
+	closeCapsule := closeSessionCapsule{ErrorCode: code, Message: msg}
+	first, err := s.closeWithError(&SessionError{ErrorCode: code, Message: msg}, &closeCapsule)
+	if !first {
 		return err
 	}
 
-	err = closeSessionStream(s.str, code, msg)
 	<-s.ctx.Done()
 	return err
 }
 
-func closeSessionStream(str http3Stream, code SessionErrorCode, msg string) error {
+func closeSessionStream(str http3Stream, closeCapsule closeSessionCapsule) error {
 	// Optimistically send the WT_CLOSE_SESSION Capsule:
 	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
 	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
 	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
-	if _, err := str.Write((closeSessionCapsule{ErrorCode: code, Message: msg}).Append(nil)); err != nil {
+	if _, err := str.Write(closeCapsule.Append(nil)); err != nil {
 		str.CancelWrite(WTSessionGoneErrorCode)
 	}
 
@@ -212,18 +280,33 @@ func (s *Session) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return s.str.ReceiveDatagram(ctx)
 }
 
-func (s *Session) closeWithError(closeErr error) (bool /* first call to close session */, error) {
+func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsule) (bool /* first call to close session */, error) {
 	s.closeMx.Lock()
-	defer s.closeMx.Unlock()
 	// Duplicate call, or the remote already closed this session.
 	if s.closeErr != nil {
+		s.closeMx.Unlock()
 		return false, nil
 	}
 	s.closeErr = closeErr
+	s.closeMx.Unlock()
 
 	s.outgoingStreams.CloseSession(closeErr)
 	s.incomingStreams.CloseSession(closeErr)
 
+	if closeCapsule != nil {
+		return true, closeSessionStream(s.str, *closeCapsule)
+	}
+
+	code := WTSessionGoneErrorCode
+	var h3Err *http3.Error
+	var strErr *quic.StreamError
+	if errors.As(closeErr, &h3Err) {
+		code = quic.StreamErrorCode(h3Err.ErrorCode)
+	} else if errors.As(closeErr, &strErr) {
+		code = strErr.ErrorCode
+	}
+	s.str.CancelRead(code)
+	s.str.CancelWrite(code)
 	return true, nil
 }
 

--- a/session.go
+++ b/session.go
@@ -56,10 +56,13 @@ type Session struct {
 	outgoingStreams outgoingStreamsMap
 }
 
-// Capsule writes can block if the peer withholds CONNECT stream flow control credit.
-// We bound the queue to avoid unbounded memory growth.
-// 4096 should be more than enough slack for normal loss/reordering.
-const maxQueuedOutgoingCapsules = 4096
+const (
+	// Capsule writes can block if the peer withholds CONNECT stream flow control credit.
+	// We bound the queue to avoid unbounded memory growth.
+	// 4096 should be more than enough slack for normal loss / reordering.
+	maxQueuedOutgoingCapsules = 4096
+	closeSessionTimeout       = 10 * time.Millisecond
+)
 
 func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str http3Stream, applicationProtocol string) *Session {
 	ctx, ctxCancel := context.WithCancel(ctx)
@@ -105,6 +108,8 @@ func (s *Session) readFromConnectStream() {
 }
 
 func (s *Session) writeToConnectStream() {
+	// This goroutine owns all writes to the CONNECT stream.
+	// WT_CLOSE_SESSION is sent from here so it doesn't race with capsule writes.
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -121,12 +126,35 @@ func (s *Session) writeToConnectStream() {
 			c := s.capsuleQueue[0]
 			s.capsuleQueueMx.Unlock()
 
-			if _, err := s.str.Write(c.Append(nil)); err != nil {
+			if closeCapsule, ok := c.(closeSessionCapsule); ok {
+				_ = closeSessionStream(s.str, closeCapsule)
+				return
+			}
+			n, err := s.str.Write(c.Append(nil))
+			if err != nil {
+				s.capsuleQueueMx.Lock()
+				closing := false
+				if len(s.capsuleQueue) > 0 {
+					_, closing = s.capsuleQueue[0].(closeSessionCapsule)
+				}
+				s.capsuleQueueMx.Unlock()
+				if closing {
+					if n > 0 {
+						s.str.CancelRead(WTSessionGoneErrorCode)
+						s.str.CancelWrite(WTSessionGoneErrorCode)
+						return
+					}
+					continue
+				}
 				s.closeWithError(err, nil)
 				return
 			}
 			s.capsuleQueueMx.Lock()
-			s.capsuleQueue = s.capsuleQueue[1:]
+			if len(s.capsuleQueue) > 0 {
+				if _, closing := s.capsuleQueue[0].(closeSessionCapsule); !closing {
+					s.capsuleQueue = s.capsuleQueue[1:]
+				}
+			}
 			s.capsuleQueueMx.Unlock()
 		}
 	}
@@ -263,7 +291,7 @@ func closeSessionStream(str http3Stream, closeCapsule closeSessionCapsule) error
 	// Optimistically send the WT_CLOSE_SESSION Capsule:
 	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
 	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
-	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
+	str.SetWriteDeadline(time.Now().Add(closeSessionTimeout))
 	if _, err := str.Write(closeCapsule.Append(nil)); err != nil {
 		str.CancelWrite(WTSessionGoneErrorCode)
 	}
@@ -294,7 +322,16 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 	s.incomingStreams.CloseSession(closeErr)
 
 	if closeCapsule != nil {
-		return true, closeSessionStream(s.str, *closeCapsule)
+		s.capsuleQueueMx.Lock()
+		s.capsuleQueue = []capsule{*closeCapsule}
+		s.capsuleQueueMx.Unlock()
+
+		s.str.SetWriteDeadline(time.Now().Add(closeSessionTimeout))
+		select {
+		case s.capsuleQueueUpdated <- struct{}{}:
+		default:
+		}
+		return true, nil
 	}
 
 	code := WTSessionGoneErrorCode

--- a/session.go
+++ b/session.go
@@ -135,16 +135,17 @@ func (s *Session) writeToConnectStream() {
 
 			n, err := s.str.Write(c.Append(nil))
 			if err != nil {
+				if n > 0 {
+					s.str.CancelRead(WTSessionGoneErrorCode)
+					s.str.CancelWrite(WTSessionGoneErrorCode)
+					s.closeWithError(err, nil)
+					return
+				}
 				if !s.closeWithError(err, nil) {
 					s.capsuleQueueMx.Lock()
 					hasClose := s.pendingCloseCapsule != nil
 					s.capsuleQueueMx.Unlock()
 					if hasClose {
-						if n > 0 {
-							s.str.CancelRead(WTSessionGoneErrorCode)
-							s.str.CancelWrite(WTSessionGoneErrorCode)
-							return
-						}
 						continue
 					}
 				}

--- a/session.go
+++ b/session.go
@@ -278,13 +278,10 @@ func (s *Session) RemoteAddr() net.Addr {
 
 func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 	closeCapsule := closeSessionCapsule{ErrorCode: code, Message: msg}
-	first, err := s.closeWithError(&SessionError{ErrorCode: code, Message: msg}, &closeCapsule)
-	if !first {
-		return err
+	if first := s.closeWithError(&SessionError{ErrorCode: code, Message: msg}, &closeCapsule); first {
+		<-s.ctx.Done()
 	}
-
-	<-s.ctx.Done()
-	return err
+	return nil
 }
 
 func closeSessionStream(str http3Stream, closeCapsule closeSessionCapsule) error {
@@ -308,12 +305,12 @@ func (s *Session) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return s.str.ReceiveDatagram(ctx)
 }
 
-func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsule) (bool /* first call to close session */, error) {
+func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsule) bool {
 	s.closeMx.Lock()
 	// Duplicate call, or the remote already closed this session.
 	if s.closeErr != nil {
 		s.closeMx.Unlock()
-		return false, nil
+		return false
 	}
 	s.closeErr = closeErr
 	s.closeMx.Unlock()
@@ -331,7 +328,7 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 		case s.capsuleQueueUpdated <- struct{}{}:
 		default:
 		}
-		return true, nil
+		return true
 	}
 
 	code := WTSessionGoneErrorCode
@@ -344,7 +341,7 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 	}
 	s.str.CancelRead(code)
 	s.str.CancelWrite(code)
-	return true, nil
+	return true
 }
 
 // SessionState returns the current state of the session

--- a/session_test.go
+++ b/session_test.go
@@ -32,6 +32,11 @@ func (s mockHTTP3Stream) CancelRead(quic.StreamErrorCode)                 {}
 func (s mockHTTP3Stream) CancelWrite(quic.StreamErrorCode)                {}
 func (s mockHTTP3Stream) SetWriteDeadline(time.Time) error                { return nil }
 
+type quicHTTP3Stream struct{ *quic.Stream }
+
+func (s quicHTTP3Stream) ReceiveDatagram(context.Context) ([]byte, error) { return nil, io.EOF }
+func (s quicHTTP3Stream) SendDatagram([]byte) error                       { return nil }
+
 func scaleDuration(d time.Duration) time.Duration {
 	if os.Getenv("CI") != "" {
 		return 5 * d
@@ -49,10 +54,10 @@ func newUDPConnLocalhost(t testing.TB) *net.UDPConn {
 
 func newConnPair(t *testing.T, clientConn, serverConn net.PacketConn) (client, server *quic.Conn) {
 	t.Helper()
-
-	ln, err := quic.ListenEarly(
+	return newConnPairWithServerConfig(
+		t,
+		clientConn,
 		serverConn,
-		TLSConf,
 		&quic.Config{
 			InitialStreamReceiveWindow:       1 << 60,
 			InitialConnectionReceiveWindow:   1 << 60,
@@ -60,6 +65,12 @@ func newConnPair(t *testing.T, clientConn, serverConn net.PacketConn) (client, s
 			EnableStreamResetPartialDelivery: true,
 		},
 	)
+}
+
+func newConnPairWithServerConfig(t *testing.T, clientConn, serverConn net.PacketConn, serverConf *quic.Config) (client, server *quic.Conn) {
+	t.Helper()
+
+	ln, err := quic.ListenEarly(serverConn, TLSConf, serverConf)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -189,4 +200,85 @@ func TestCapsuleParseErrorClosesSessionWithDatagramError(t *testing.T) {
 
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
 	require.ErrorContains(t, err, "trailing data")
+}
+
+func TestSessionSendsQueuedCapsules(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+
+	clientStr, err := clientConn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	sess := newSession(context.Background(), 42, clientConn, quicHTTP3Stream{clientStr}, "")
+	sess.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: 42})
+	sess.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: 1337})
+
+	serverStr, err := serverConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, serverStr.SetReadDeadline(time.Now().Add(time.Second)))
+
+	c, err := parseNextCapsule(serverStr)
+	require.NoError(t, err)
+	require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: 42}, c)
+	c, err = parseNextCapsule(serverStr)
+	require.NoError(t, err)
+	require.Equal(t, streamsBlockedUniCapsule{MaximumStreams: 1337}, c)
+}
+
+func TestSessionClosesWhenOutgoingCapsuleQueueFull(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	clientConn, serverConn := newConnPairWithServerConfig(
+		t,
+		newUDPConnLocalhost(t),
+		newUDPConnLocalhost(t),
+		&quic.Config{
+			InitialStreamReceiveWindow:       1,
+			MaxStreamReceiveWindow:           1,
+			InitialConnectionReceiveWindow:   1,
+			MaxConnectionReceiveWindow:       1,
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	)
+
+	clientStr, err := clientConn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+
+	_, err = clientStr.Write([]byte{0})
+	require.NoError(t, err)
+	serverStr, err := serverConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, serverStr.SetReadDeadline(time.Now().Add(time.Second)))
+	_, err = io.ReadFull(serverStr, make([]byte, 1))
+	require.NoError(t, err)
+	require.NoError(t, serverStr.SetReadDeadline(time.Time{}))
+
+	// Fill quic-go's per-stream packet buffer. With the peer window capped at 1,
+	// the next capsule write stays blocked while we fill our capsule queue.
+	_, err = clientStr.Write(make([]byte, 1450))
+	require.NoError(t, err)
+
+	sess := newSession(context.Background(), 0, clientConn, quicHTTP3Stream{clientStr}, "")
+	for range maxQueuedOutgoingCapsules {
+		sess.queueCapsule(streamsBlockedBidiCapsule{})
+	}
+	sess.queueCapsule(streamsBlockedUniCapsule{})
+
+	b := make([]byte, 1024)
+	require.NoError(t, serverStr.SetReadDeadline(time.Now().Add(time.Second)))
+	for err == nil {
+		_, err = serverStr.Read(b)
+	}
+	require.ErrorIs(t, err, &quic.StreamError{
+		StreamID:  serverStr.StreamID(),
+		ErrorCode: quic.StreamErrorCode(http3.ErrCodeExcessiveLoad),
+		Remote:    true,
+	})
+
+	_, err = sess.OpenStream()
+	var h3Err *http3.Error
+	require.ErrorAs(t, err, &h3Err)
+	require.Equal(t, http3.ErrCodeExcessiveLoad, h3Err.ErrorCode)
 }

--- a/session_test.go
+++ b/session_test.go
@@ -282,3 +282,50 @@ func TestSessionClosesWhenOutgoingCapsuleQueueFull(t *testing.T) {
 	require.ErrorAs(t, err, &h3Err)
 	require.Equal(t, http3.ErrCodeExcessiveLoad, h3Err.ErrorCode)
 }
+
+func TestCloseWithErrorDropsQueuedCapsulesWhenConnectStreamBlocked(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	clientConn, serverConn := newConnPairWithServerConfig(
+		t,
+		newUDPConnLocalhost(t),
+		newUDPConnLocalhost(t),
+		&quic.Config{
+			InitialStreamReceiveWindow:       1,
+			MaxStreamReceiveWindow:           1,
+			InitialConnectionReceiveWindow:   1,
+			MaxConnectionReceiveWindow:       1,
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	)
+
+	clientStr, err := clientConn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+
+	_, err = clientStr.Write([]byte{0})
+	require.NoError(t, err)
+	serverStr, err := serverConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, serverStr.SetReadDeadline(time.Now().Add(time.Second)))
+	_, err = io.ReadFull(serverStr, make([]byte, 1))
+	require.NoError(t, err)
+	require.NoError(t, serverStr.SetReadDeadline(time.Time{}))
+
+	_, err = clientStr.Write(make([]byte, 1450))
+	require.NoError(t, err)
+
+	sess := newSession(context.Background(), 0, clientConn, quicHTTP3Stream{clientStr}, "")
+	sess.queueCapsule(streamsBlockedBidiCapsule{})
+
+	done := make(chan error, 1)
+	go func() { done <- sess.CloseWithError(42, "close") }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}


### PR DESCRIPTION
Needed for #296, and all the other flow control related capsules.

The fundamental problem here is that sending capsules might get blocked by a malicious peer that doesn’t issue flow control credits for the CONNECT stream. We therefore implement a very generous limit of 4096 queued capsules and close the WebTransport session with an H3_EXCESSIVE_LOAD error if that limit is surpassed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement async capsule sending with a bounded queue in WebTransport sessions
> - Adds a dedicated `writeToConnectStream` goroutine in [session.go](https://github.com/quic-go/webtransport-go/pull/301/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) that serializes all CONNECT stream writes, replacing inline writes scattered across the session.
> - Introduces a bounded outgoing capsule queue (max 4096 entries via `queueCapsule`) so capsule producers don't need to block on I/O directly.
> - `CloseWithError` now enqueues a `WT_CLOSE_SESSION` capsule, drops any other queued capsules, and blocks until the session context is done rather than writing inline.
> - If the capsule queue is full, the session closes immediately with `http3.ErrCodeExcessiveLoad`.
> - Risk: `CloseWithError` is now async and blocks until session shutdown; callers that previously expected a synchronous write will observe different timing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 183a6a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->