### PR TITLE
ci: fix race condition in example workflow

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -21,8 +21,16 @@ jobs:
           server_pid=$!
           trap 'kill "$server_pid" 2>/dev/null || true' EXIT
 
-          sleep 5
-          cert_hash="$(sed -n 's/^Server Certificate Hash: //p' "$server_log" | head -n 1)"
+          for _ in {1..30}; do
+            cert_hash="$(sed -n 's/^Server Certificate Hash: //p' "$server_log" | head -n 1)"
+            if [ -n "$cert_hash" ]; then
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
           if [ -z "$cert_hash" ]; then
             cat "$server_log"
             exit 1


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix race condition in example workflow by replacing fixed sleep with a polling loop
Replaces the fixed `sleep 5` in [example.yml](.github/workflows/example.yml) with a polling loop that checks for the certificate hash up to 30 times, sleeping 1 second between attempts. The loop breaks early if the hash is found or the server process exits, avoiding both the race condition and unnecessary waiting.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b20efd5.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->