### PR TITLE
add support for sending WT_STREAMS_BLOCKED capsules

### DIFF
--- a/session.go
+++ b/session.go
@@ -76,7 +76,7 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		capsuleQueueUpdated: make(chan struct{}, 1),
 		incomingStreams:     *newIncomingStreamsMap(ctx),
 	}
-	c.outgoingStreams = *newOutgoingStreamsMap(conn, sessionID)
+	c.outgoingStreams = *newOutgoingStreamsMap(conn, sessionID, c.queueCapsule)
 
 	go func() {
 		defer ctxCancel()

--- a/stream_test.go
+++ b/stream_test.go
@@ -332,7 +332,9 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newOutgoingStreamsMap(nil, 0)
+	sm := newOutgoingStreamsMap(nil, 0, func(c capsule) {
+		t.Fatalf("unexpected capsule: %#v", c)
+	})
 	str := newSendStream(sendStr, nil, func() { sm.removeStream(sendStr.StreamID()) })
 	sm.mx.Lock()
 	sm.m[sendStr.StreamID()] = str.closeWithSession

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -23,14 +23,16 @@ const maxOutgoingStreams = 1 << 60
 type outgoingStreamLimit struct {
 	OpenQueue []chan struct{}
 
-	NumStreams uint64 // total number of streams opened for this session
-	MaxStreams uint64 // stream limit, as advertised by the peer
+	NumStreams  uint64 // total number of streams opened for this session
+	MaxStreams  uint64 // stream limit, as advertised by the peer
+	BlockedSent bool   // was a WT_STREAMS_BLOCKED sent for the current MaxStreams
 }
 
 type outgoingStreamsMap struct {
 	conn         *quic.Conn
 	streamHdr    []byte
 	uniStreamHdr []byte
+	queueCapsule func(capsule)
 
 	mx         sync.Mutex
 	closeErr   error
@@ -40,7 +42,7 @@ type outgoingStreamsMap struct {
 	m          map[quic.StreamID]func(error)
 }
 
-func newOutgoingStreamsMap(conn *quic.Conn, sessionID sessionID) *outgoingStreamsMap {
+func newOutgoingStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap {
 	uniStreamHdr := make([]byte, 0, 2+quicvarint.Len(uint64(sessionID)))
 	uniStreamHdr = quicvarint.Append(uniStreamHdr, webTransportUniStreamType)
 	uniStreamHdr = quicvarint.Append(uniStreamHdr, uint64(sessionID))
@@ -53,6 +55,7 @@ func newOutgoingStreamsMap(conn *quic.Conn, sessionID sessionID) *outgoingStream
 		conn:         conn,
 		streamHdr:    streamHdr,
 		uniStreamHdr: uniStreamHdr,
+		queueCapsule: queueCapsule,
 		streamCtxs:   make(map[int]context.CancelFunc),
 		bidiLimit:    outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
 		uniLimit:     outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
@@ -80,13 +83,26 @@ func (s *outgoingStreamsMap) addSendStream(qstr *quic.SendStream) *SendStream {
 
 func (s *outgoingStreamsMap) OpenStream() (*Stream, error) {
 	s.mx.Lock()
-	defer s.mx.Unlock()
 
 	if s.closeErr != nil {
+		s.mx.Unlock()
 		return nil, s.closeErr
 	}
-	// if there are OpenStreamSync calls waiting, return an error here
-	if len(s.bidiLimit.OpenQueue) > 0 || s.bidiLimit.NumStreams >= s.bidiLimit.MaxStreams {
+	if len(s.bidiLimit.OpenQueue) > 0 {
+		s.mx.Unlock()
+		return nil, &StreamLimitReachedError{}
+	}
+
+	if s.bidiLimit.NumStreams >= s.bidiLimit.MaxStreams {
+		sendBlocked := !s.bidiLimit.BlockedSent
+		maxStreams := s.bidiLimit.MaxStreams
+		if sendBlocked {
+			s.bidiLimit.BlockedSent = true
+		}
+		s.mx.Unlock()
+		if sendBlocked {
+			s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
+		}
 		return nil, &StreamLimitReachedError{}
 	}
 	s.bidiLimit.NumStreams++
@@ -95,9 +111,12 @@ func (s *outgoingStreamsMap) OpenStream() (*Stream, error) {
 	if err != nil {
 		s.bidiLimit.NumStreams--
 		s.maybeUnblockOpenSync(&s.bidiLimit)
+		s.mx.Unlock()
 		return nil, err
 	}
-	return s.addStream(qstr), nil
+	str := s.addStream(qstr)
+	s.mx.Unlock()
+	return str, nil
 }
 
 func (s *outgoingStreamsMap) addStreamCtxCancel(cancel context.CancelFunc) (id int) {
@@ -116,7 +135,7 @@ func (s *outgoingStreamsMap) OpenStreamSync(ctx context.Context) (*Stream, error
 		s.mx.Unlock()
 		return nil, s.closeErr
 	}
-	if err := s.waitForStreamLimit(ctx, &s.bidiLimit); err != nil {
+	if err := s.waitForStreamLimit(ctx, &s.bidiLimit, true); err != nil {
 		s.mx.Unlock()
 		return nil, err
 	}
@@ -151,13 +170,25 @@ func (s *outgoingStreamsMap) OpenStreamSync(ctx context.Context) (*Stream, error
 
 func (s *outgoingStreamsMap) OpenUniStream() (*SendStream, error) {
 	s.mx.Lock()
-	defer s.mx.Unlock()
 
 	if s.closeErr != nil {
+		s.mx.Unlock()
 		return nil, s.closeErr
 	}
-	// if there are OpenUniStreamSync calls waiting, return an error here
-	if len(s.uniLimit.OpenQueue) > 0 || s.uniLimit.NumStreams >= s.uniLimit.MaxStreams {
+	if len(s.uniLimit.OpenQueue) > 0 {
+		s.mx.Unlock()
+		return nil, &StreamLimitReachedError{}
+	}
+	if s.uniLimit.NumStreams >= s.uniLimit.MaxStreams {
+		sendBlocked := !s.uniLimit.BlockedSent
+		maxStreams := s.uniLimit.MaxStreams
+		if sendBlocked {
+			s.uniLimit.BlockedSent = true
+		}
+		s.mx.Unlock()
+		if sendBlocked {
+			s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
+		}
 		return nil, &StreamLimitReachedError{}
 	}
 	s.uniLimit.NumStreams++
@@ -165,9 +196,12 @@ func (s *outgoingStreamsMap) OpenUniStream() (*SendStream, error) {
 	if err != nil {
 		s.uniLimit.NumStreams--
 		s.maybeUnblockOpenSync(&s.uniLimit)
+		s.mx.Unlock()
 		return nil, err
 	}
-	return s.addSendStream(qstr), nil
+	str := s.addSendStream(qstr)
+	s.mx.Unlock()
+	return str, nil
 }
 
 func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendStream, err error) {
@@ -176,7 +210,7 @@ func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendSt
 		s.mx.Unlock()
 		return nil, s.closeErr
 	}
-	if err := s.waitForStreamLimit(ctx, &s.uniLimit); err != nil {
+	if err := s.waitForStreamLimit(ctx, &s.uniLimit, false); err != nil {
 		s.mx.Unlock()
 		return nil, err
 	}
@@ -208,7 +242,7 @@ func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendSt
 	return s.addSendStream(qstr), nil
 }
 
-func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit *outgoingStreamLimit) error {
+func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit *outgoingStreamLimit, bidirectional bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -220,41 +254,68 @@ func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit
 	waitChan := make(chan struct{}, 1)
 	streamLimit.OpenQueue = append(streamLimit.OpenQueue, waitChan)
 
-	for {
+	if streamLimit.NumStreams >= streamLimit.MaxStreams && !streamLimit.BlockedSent {
+		streamLimit.BlockedSent = true
+		maxStreams := streamLimit.MaxStreams
 		s.mx.Unlock()
-		select {
-		case <-ctx.Done():
-			s.mx.Lock()
-			streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
-				return c == waitChan
-			})
-			// If we just received a WT_MAX_STREAMS capsule, this might have been the next stream
-			// that could be opened. Make sure we unblock the next OpenStreamSync call.
-			s.maybeUnblockOpenSync(streamLimit)
-			return ctx.Err()
-		case <-waitChan:
+		if bidirectional {
+			s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
+		} else {
+			s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
 		}
-
 		s.mx.Lock()
 		if s.closeErr != nil {
 			return s.closeErr
 		}
-		if err := ctx.Err(); err != nil {
-			streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
-				return c == waitChan
-			})
-			s.maybeUnblockOpenSync(streamLimit)
-			return err
-		}
-		if streamLimit.NumStreams >= streamLimit.MaxStreams {
-			// no stream available. Continue waiting.
-			continue
-		}
-		streamLimit.NumStreams++
-		streamLimit.OpenQueue = streamLimit.OpenQueue[1:]
-		s.maybeUnblockOpenSync(streamLimit)
-		return nil
 	}
+
+	s.mx.Unlock()
+	select {
+	case <-ctx.Done():
+		s.mx.Lock()
+		streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+			return c == waitChan
+		})
+		// If we just received a WT_MAX_STREAMS capsule, this might have been the next stream
+		// that could be opened. Make sure we unblock the next OpenStreamSync call.
+		s.maybeUnblockOpenSync(streamLimit)
+		return ctx.Err()
+	case <-waitChan:
+	}
+
+	s.mx.Lock()
+	if s.closeErr != nil {
+		return s.closeErr
+	}
+	if err := ctx.Err(); err != nil {
+		streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+			return c == waitChan
+		})
+		s.maybeUnblockOpenSync(streamLimit)
+		return err
+	}
+
+	streamLimit.NumStreams++
+	streamLimit.OpenQueue = streamLimit.OpenQueue[1:]
+	if len(streamLimit.OpenQueue) > 0 && streamLimit.NumStreams >= streamLimit.MaxStreams {
+		if !streamLimit.BlockedSent {
+			streamLimit.BlockedSent = true
+			maxStreams := streamLimit.MaxStreams
+			s.mx.Unlock()
+			if bidirectional {
+				s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
+			} else {
+				s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
+			}
+			s.mx.Lock()
+			if s.closeErr != nil {
+				return s.closeErr
+			}
+		}
+	} else {
+		s.maybeUnblockOpenSync(streamLimit)
+	}
+	return nil
 }
 
 func (s *outgoingStreamsMap) UpdateBidiStreamLimit(limit uint64) {
@@ -273,6 +334,7 @@ func (s *outgoingStreamsMap) updateStreamLimit(streamLimit *outgoingStreamLimit,
 		return
 	}
 	streamLimit.MaxStreams = limit
+	streamLimit.BlockedSent = false
 	s.maybeUnblockOpenSync(streamLimit)
 }
 

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -27,7 +27,9 @@ func TestOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T) {
 
 func testOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T, openStream, openStreamSync func(*outgoingStreamsMap) error) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newOutgoingStreamsMap(clientConn, 42)
+	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) {
+		t.Fatalf("unexpected capsule: %#v", c)
+	})
 
 	for {
 		if err := openStream(streams); err != nil {
@@ -57,20 +59,71 @@ func testOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T, openStream, 
 
 func TestOutgoingStreamsMapOpenStreamLimit(t *testing.T) {
 	t.Run("bidirectional", func(t *testing.T) {
-		streams := newOutgoingStreamsMap(nil, 42)
+		var capsules []capsule
+		streams := newOutgoingStreamsMap(nil, 42, func(c capsule) { capsules = append(capsules, c) })
 		streams.bidiLimit.MaxStreams = 0
 		_, err := streams.OpenStream()
 		var limitErr *StreamLimitReachedError
 		require.ErrorAs(t, err, &limitErr)
+		require.Equal(t, []capsule{streamsBlockedBidiCapsule{MaximumStreams: 0}}, capsules)
+
+		_, err = streams.OpenStream()
+		require.ErrorAs(t, err, &limitErr)
+		require.Len(t, capsules, 1)
 	})
 
 	t.Run("unidirectional", func(t *testing.T) {
-		streams := newOutgoingStreamsMap(nil, 42)
+		var capsules []capsule
+		streams := newOutgoingStreamsMap(nil, 42, func(c capsule) { capsules = append(capsules, c) })
 		streams.uniLimit.MaxStreams = 0
 		_, err := streams.OpenUniStream()
 		var limitErr *StreamLimitReachedError
 		require.ErrorAs(t, err, &limitErr)
+		require.Equal(t, []capsule{streamsBlockedUniCapsule{MaximumStreams: 0}}, capsules)
+
+		_, err = streams.OpenUniStream()
+		require.ErrorAs(t, err, &limitErr)
+		require.Len(t, capsules, 1)
 	})
+}
+
+func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
+	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+	capsuleChan := make(chan capsule, 2)
+	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
+	streams.bidiLimit.MaxStreams = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := streams.OpenStreamSync(ctx)
+		errChan <- err
+	}()
+
+	select {
+	case c := <-capsuleChan:
+		require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: 0}, c)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for capsule")
+	}
+
+	_, err := streams.OpenStream()
+	var limitErr *StreamLimitReachedError
+	require.ErrorAs(t, err, &limitErr)
+	select {
+	case c := <-capsuleChan:
+		t.Fatalf("unexpected capsule: %#v", c)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream cancellation")
+	}
 }
 
 func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
@@ -80,6 +133,8 @@ func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
 			func(m *outgoingStreamsMap) error { _, err := m.OpenStream(); return err },
 			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenStreamSync(ctx); return err },
 			(*outgoingStreamsMap).UpdateBidiStreamLimit,
+			streamsBlockedBidiCapsule{MaximumStreams: 0},
+			streamsBlockedBidiCapsule{MaximumStreams: 1},
 		)
 	})
 
@@ -89,6 +144,8 @@ func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
 			func(m *outgoingStreamsMap) error { _, err := m.OpenUniStream(); return err },
 			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenUniStreamSync(ctx); return err },
 			(*outgoingStreamsMap).UpdateUniStreamLimit,
+			streamsBlockedUniCapsule{MaximumStreams: 0},
+			streamsBlockedUniCapsule{MaximumStreams: 1},
 		)
 	})
 }
@@ -98,9 +155,12 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 	openStream func(*outgoingStreamsMap) error,
 	openStreamSync func(*outgoingStreamsMap, context.Context) error,
 	updateLimit func(*outgoingStreamsMap, uint64),
+	initialBlocked capsule,
+	nextBlocked capsule,
 ) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newOutgoingStreamsMap(clientConn, 42)
+	capsuleChan := make(chan capsule, 2)
+	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
 	streams.bidiLimit.MaxStreams = 0
 	streams.uniLimit.MaxStreams = 0
 
@@ -115,6 +175,12 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 		t.Fatal("should not have opened stream")
 	case <-time.After(scaleDuration(10 * time.Millisecond)):
 	}
+	select {
+	case c := <-capsuleChan:
+		require.Equal(t, initialBlocked, c)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for capsule")
+	}
 
 	updateLimit(streams, 1)
 
@@ -124,10 +190,21 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	}
+	select {
+	case c := <-capsuleChan:
+		t.Fatalf("unexpected capsule: %#v", c)
+	default:
+	}
 
 	err := openStream(streams)
 	var limitErr *StreamLimitReachedError
 	require.ErrorAs(t, err, &limitErr)
+	select {
+	case c := <-capsuleChan:
+		require.Equal(t, nextBlocked, c)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for capsule")
+	}
 
 	go func() { errChan <- openStreamSync(streams, ctx) }()
 	select {
@@ -139,10 +216,11 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 
 func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newOutgoingStreamsMap(clientConn, 42)
+	const numStreams = 16
+	capsuleChan := make(chan capsule, numStreams)
+	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
 	streams.bidiLimit.MaxStreams = 0
 
-	const numStreams = 16
 	type result struct {
 		index int
 		err   error
@@ -159,6 +237,17 @@ func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 			return len(streams.bidiLimit.OpenQueue) == i+1
 		}, time.Second, scaleDuration(time.Millisecond))
 	}
+	select {
+	case c := <-capsuleChan:
+		require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: 0}, c)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for capsule")
+	}
+	select {
+	case c := <-capsuleChan:
+		t.Fatalf("unexpected capsule: %#v", c)
+	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	}
 
 	for i := range numStreams {
 		streams.UpdateBidiStreamLimit(uint64(i + 1))
@@ -168,6 +257,20 @@ func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 			require.Equal(t, i, r.index)
 		case <-time.After(time.Second):
 			t.Fatal("timeout")
+		}
+		if i == numStreams-1 {
+			select {
+			case c := <-capsuleChan:
+				t.Fatalf("unexpected capsule: %#v", c)
+			default:
+			}
+			continue
+		}
+		select {
+		case c := <-capsuleChan:
+			require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: uint64(i + 1)}, c)
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for capsule")
 		}
 	}
 }


### PR DESCRIPTION
Part of #296.

This now adds quite a bit of duplicate code to the outgoing streams map. We will clean this up in a follow-up PR, most likely by introducing a generic version.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WT_STREAMS_BLOCKED capsule sending to outgoing streams map
> - Adds `queueCapsule` callback to `outgoingStreamsMap` in [streams_map_outgoing.go](https://github.com/quic-go/webtransport-go/pull/304/files#diff-c615463dd5462bd1b530fa8c6fa108413a258c0d8c7f268fd31d44c8d371ab33), enabling it to emit `WT_STREAMS_BLOCKED` capsules when bidi or uni stream limits are hit.
> - `OpenStream` and `OpenUniStream` queue a blocked capsule once per current `MaxStreams` value, then return `StreamLimitReachedError` without holding the mutex during capsule emission.
> - `waitForStreamLimit` (used by `OpenStreamSync`/`OpenUniStreamSync`) also emits a blocked capsule once per limit window, resetting when the limit increases via `updateStreamLimit`.
> - [session.go](https://github.com/quic-go/webtransport-go/pull/304/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) wires the session's `queueCapsule` method into the `newOutgoingStreamsMap` constructor call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad23478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->