### PR TITLE
reject WT_MAX_STREAM_DATA and WT_STREAM_DATA_BLOCKED capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -12,8 +12,10 @@ import (
 
 const (
 	closeSessionCapsuleType       http3.CapsuleType = 0x2843
+	maxStreamDataCapsuleType      http3.CapsuleType = 0x190b4d3e // only used on WebTransport over HTTP/2
 	maxStreamsBidiCapsuleType     http3.CapsuleType = 0x190b4d3f
 	maxStreamsUniCapsuleType      http3.CapsuleType = 0x190b4d40
+	streamDataBlockedCapsuleType  http3.CapsuleType = 0x190b4d42 // only used on WebTransport over HTTP/2
 	streamsBlockedBidiCapsuleType http3.CapsuleType = 0x190b4d43
 	streamsBlockedUniCapsuleType  http3.CapsuleType = 0x190b4d44
 )
@@ -41,6 +43,8 @@ func parseNextCapsule(r io.Reader) (capsule, error) {
 				return nil, err
 			}
 			return capsule, nil
+		case maxStreamDataCapsuleType:
+			return nil, errors.New("WT_MAX_STREAM_DATA capsule received")
 		case maxStreamsBidiCapsuleType:
 			maxStreams, err := parseMaxStreamsCapsule(capsuleReader)
 			if err != nil {
@@ -53,6 +57,8 @@ func parseNextCapsule(r io.Reader) (capsule, error) {
 				return nil, err
 			}
 			return maxStreamsUniCapsule{MaximumStreams: maxStreams}, nil
+		case streamDataBlockedCapsuleType:
+			return nil, errors.New("WT_STREAM_DATA_BLOCKED capsule received")
 		case streamsBlockedBidiCapsuleType:
 			maxStreams, err := parseStreamsBlockedCapsule(capsuleReader)
 			if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -202,6 +202,44 @@ func TestCapsuleParseErrorClosesSessionWithDatagramError(t *testing.T) {
 	require.ErrorContains(t, err, "trailing data")
 }
 
+func TestForbiddenStreamDataFlowControlCapsulesCloseSession(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		typ  http3.CapsuleType
+		msg  string
+	}{
+		{
+			name: "WT_MAX_STREAM_DATA",
+			typ:  maxStreamDataCapsuleType,
+			msg:  "WT_MAX_STREAM_DATA capsule received",
+		},
+		{
+			name: "WT_STREAM_DATA_BLOCKED",
+			typ:  streamDataBlockedCapsuleType,
+			msg:  "WT_STREAM_DATA_BLOCKED capsule received",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := quicvarint.Append(nil, uint64(tc.typ))
+			b = quicvarint.Append(b, 0)
+
+			sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+			select {
+			case <-sess.Context().Done():
+			case <-time.After(time.Second):
+				t.Fatal("timeout")
+			}
+
+			sess.closeMx.Lock()
+			err := sess.closeErr
+			sess.closeMx.Unlock()
+
+			require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeDatagramError})
+			require.ErrorContains(t, err, tc.msg)
+		})
+	}
+}
+
 func TestSessionSendsQueuedCapsules(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()


### PR DESCRIPTION
These capsules are not for for the HTTP/3 version of WebTransport They are, however, defined for for the HTTP/2 version. It's a little bit weird that we have to parse this capsule just to reject it, but it does make it easier to surface implementation errors when proxying WebTransport sessions on different HTTP versions.

Part of #256.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject WT_MAX_STREAM_DATA and WT_STREAM_DATA_BLOCKED capsules in WebTransport sessions
> Adds explicit handling in `parseNextCapsule` ([capsule.go](https://github.com/quic-go/webtransport-go/pull/305/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6)) for `WT_MAX_STREAM_DATA` and `WT_STREAM_DATA_BLOCKED` capsule types, returning an error instead of silently skipping them. These capsule types are only valid on WebTransport over HTTP/2 and should never appear in the current context. A new table-driven test in [session_test.go](https://github.com/quic-go/webtransport-go/pull/305/files#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557) verifies that receiving either capsule closes the session with an `http3.Error` using `ErrCodeDatagramError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78df2a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->