### PR TITLE
add support for parsing and writing WT_MAX_DATA capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	closeSessionCapsuleType       http3.CapsuleType = 0x2843
+	maxDataCapsuleType            http3.CapsuleType = 0x190b4d3d
 	maxStreamDataCapsuleType      http3.CapsuleType = 0x190b4d3e // only used on WebTransport over HTTP/2
 	maxStreamsBidiCapsuleType     http3.CapsuleType = 0x190b4d3f
 	maxStreamsUniCapsuleType      http3.CapsuleType = 0x190b4d40
@@ -43,6 +44,12 @@ func parseNextCapsule(r io.Reader) (capsule, error) {
 				return nil, err
 			}
 			return capsule, nil
+		case maxDataCapsuleType:
+			maxData, err := parseMaxDataCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return maxDataCapsule{MaximumData: maxData}, nil
 		case maxStreamDataCapsuleType:
 			return nil, errors.New("WT_MAX_STREAM_DATA capsule received")
 		case maxStreamsBidiCapsuleType:
@@ -122,6 +129,16 @@ func (c closeSessionCapsule) ToSessionError() *SessionError {
 	}
 }
 
+type maxDataCapsule struct {
+	MaximumData uint64
+}
+
+func (c maxDataCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(maxDataCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumData)))
+	return quicvarint.Append(b, c.MaximumData)
+}
+
 type maxStreamsBidiCapsule struct {
 	MaximumStreams uint64
 }
@@ -160,6 +177,20 @@ func (c streamsBlockedUniCapsule) Append(b []byte) []byte {
 	b = quicvarint.Append(b, uint64(streamsBlockedUniCapsuleType))
 	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
 	return quicvarint.Append(b, c.MaximumStreams)
+}
+
+func parseMaxDataCapsule(r io.Reader) (uint64, error) {
+	maxData, err := quicvarint.Read(quicvarint.NewReader(r))
+	if err != nil {
+		return 0, err
+	}
+	var extra [1]byte
+	if _, err := io.ReadFull(r, extra[:]); err == nil {
+		return 0, errors.New("WT_MAX_DATA capsule has trailing data")
+	} else if err != io.EOF {
+		return 0, err
+	}
+	return maxData, nil
 }
 
 func parseMaxStreamsCapsule(r io.Reader) (uint64, error) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -55,6 +55,23 @@ func TestCloseSessionCapsuleRoundTrip(t *testing.T) {
 	require.Equal(t, closeSessionCapsule{ErrorCode: 42, Message: "all good"}, c)
 }
 
+func TestMaxDataCapsuleRoundTrip(t *testing.T) {
+	var b bytes.Buffer
+	c := maxDataCapsule{MaximumData: 1337}
+	b.Write(c.Append(nil))
+
+	typ, r, err := http3.ParseCapsule(quicvarint.NewReader(&b))
+	require.NoError(t, err)
+	require.Equal(t, maxDataCapsuleType, typ)
+	maxData, err := quicvarint.Read(quicvarint.NewReader(r))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1337), maxData)
+
+	parsed, err := parseNextCapsule(bytes.NewReader(c.Append(nil)))
+	require.NoError(t, err)
+	require.Equal(t, c, parsed)
+}
+
 func TestMaxStreamsCapsuleRoundTrip(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -145,6 +162,16 @@ func TestParseStreamsBlockedCapsuleTooLarge(t *testing.T) {
 
 	_, err := parseNextCapsule(&b)
 	require.ErrorContains(t, err, "WT_STREAMS_BLOCKED value too large")
+}
+
+func TestParseMaxDataCapsuleTrailingData(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(maxDataCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	_, err := parseNextCapsule(bytes.NewReader(b))
+	require.ErrorContains(t, err, "WT_MAX_DATA capsule has trailing data")
 }
 
 func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add parsing and serialization support for `WT_MAX_DATA` capsules
Adds the `maxDataCapsuleType` constant, `maxDataCapsule` struct, and `parseMaxDataCapsule` function to [capsule.go](https://github.com/quic-go/webtransport-go/pull/306/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6). Previously, `WT_MAX_DATA` capsules were treated as unknown and skipped; they are now parsed into a `maxDataCapsule` with a `MaximumData` field and can be serialized back to wire format via `Append`. Parsing rejects capsules with trailing data after the varint-encoded value.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 095d318.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->