### PR TITLE
use a generic implementation for the outgoing streams map

### DIFF
--- a/session.go
+++ b/session.go
@@ -53,8 +53,9 @@ type Session struct {
 	pendingCloseCapsule *closeSessionCapsule
 	capsuleQueueUpdated chan struct{}
 
-	incomingStreams incomingStreamsMap
-	outgoingStreams outgoingStreamsMap
+	incomingStreams    incomingStreamsMap
+	outgoingStreams    *outgoingStreamsMap[*Stream]
+	outgoingUniStreams *outgoingStreamsMap[*SendStream]
 }
 
 const (
@@ -76,7 +77,8 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		capsuleQueueUpdated: make(chan struct{}, 1),
 		incomingStreams:     *newIncomingStreamsMap(ctx),
 	}
-	c.outgoingStreams = *newOutgoingStreamsMap(conn, sessionID, c.queueCapsule)
+	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, c.queueCapsule)
+	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, c.queueCapsule)
 
 	go func() {
 		defer ctxCancel()
@@ -245,7 +247,7 @@ func (s *Session) OpenUniStream() (*SendStream, error) {
 	if s.closeErr != nil {
 		return nil, s.closeErr
 	}
-	return s.outgoingStreams.OpenUniStream()
+	return s.outgoingUniStreams.OpenStream()
 }
 
 func (s *Session) OpenUniStreamSync(ctx context.Context) (str *SendStream, err error) {
@@ -256,7 +258,7 @@ func (s *Session) OpenUniStreamSync(ctx context.Context) (str *SendStream, err e
 	}
 	s.closeMx.Unlock()
 
-	str, err = s.outgoingStreams.OpenUniStreamSync(ctx)
+	str, err = s.outgoingUniStreams.OpenStreamSync(ctx)
 
 	s.closeMx.Lock()
 	defer s.closeMx.Unlock()
@@ -316,6 +318,7 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 	s.closeMx.Unlock()
 
 	s.outgoingStreams.CloseSession(closeErr)
+	s.outgoingUniStreams.CloseSession(closeErr)
 	s.incomingStreams.CloseSession(closeErr)
 
 	if closeCapsule != nil {

--- a/stream_test.go
+++ b/stream_test.go
@@ -332,12 +332,12 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newOutgoingStreamsMap(nil, 0, func(c capsule) {
+	sm := newOutgoingUniStreamsMap(nil, 0, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
 	str := newSendStream(sendStr, nil, func() { sm.removeStream(sendStr.StreamID()) })
 	sm.mx.Lock()
-	sm.m[sendStr.StreamID()] = str.closeWithSession
+	sm.m[sendStr.StreamID()] = str
 	sm.mx.Unlock()
 
 	// write in a loop

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -18,108 +18,145 @@ func (e StreamLimitReachedError) Error() string { return "too many open streams"
 
 const maxOutgoingStreams = 1 << 60
 
-// outgoingStreamLimit tracks the number of WebTransport streams opened against
-// the peer's advertised stream limit.
-type outgoingStreamLimit struct {
-	OpenQueue []chan struct{}
-
-	NumStreams  uint64 // total number of streams opened for this session
-	MaxStreams  uint64 // stream limit, as advertised by the peer
-	BlockedSent bool   // was a WT_STREAMS_BLOCKED sent for the current MaxStreams
+type outgoingStream interface {
+	*Stream | *SendStream
+	closeWithSession(error)
 }
 
-type outgoingStreamsMap struct {
-	conn         *quic.Conn
-	streamHdr    []byte
-	uniStreamHdr []byte
-	queueCapsule func(capsule)
+type outgoingStreamsMap[T outgoingStream] struct {
+	openStream     func() (T, quic.StreamID, error)
+	openStreamSync func(context.Context) (T, quic.StreamID, error)
+	queueBlocked   func(uint64)
 
 	mx         sync.Mutex
 	closeErr   error
 	streamCtxs map[int]context.CancelFunc
-	bidiLimit  outgoingStreamLimit
-	uniLimit   outgoingStreamLimit
-	m          map[quic.StreamID]func(error)
+
+	openQueue   []chan struct{}
+	numStreams  uint64 // total number of streams opened for this session
+	maxStreams  uint64 // stream limit, as advertised by the peer
+	blockedSent bool   // was a WT_STREAMS_BLOCKED sent for the current maxStreams
+
+	m map[quic.StreamID]T
 }
 
-func newOutgoingStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap {
-	uniStreamHdr := make([]byte, 0, 2+quicvarint.Len(uint64(sessionID)))
-	uniStreamHdr = quicvarint.Append(uniStreamHdr, webTransportUniStreamType)
-	uniStreamHdr = quicvarint.Append(uniStreamHdr, uint64(sessionID))
-
-	streamHdr := make([]byte, 0, 2+quicvarint.Len(uint64(sessionID)))
-	streamHdr = quicvarint.Append(streamHdr, webTransportFrameType)
-	streamHdr = quicvarint.Append(streamHdr, uint64(sessionID))
-
-	return &outgoingStreamsMap{
-		conn:         conn,
-		streamHdr:    streamHdr,
-		uniStreamHdr: uniStreamHdr,
-		queueCapsule: queueCapsule,
-		streamCtxs:   make(map[int]context.CancelFunc),
-		bidiLimit:    outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
-		uniLimit:     outgoingStreamLimit{MaxStreams: maxOutgoingStreams},
-		m:            make(map[quic.StreamID]func(error)),
+func newOutgoingStreamsMap[T outgoingStream](
+	openStream func() (T, quic.StreamID, error),
+	openStreamSync func(context.Context) (T, quic.StreamID, error),
+	queueBlocked func(uint64),
+) *outgoingStreamsMap[T] {
+	return &outgoingStreamsMap[T]{
+		openStream:     openStream,
+		openStreamSync: openStreamSync,
+		queueBlocked:   queueBlocked,
+		streamCtxs:     make(map[int]context.CancelFunc),
+		maxStreams:     maxOutgoingStreams,
+		m:              make(map[quic.StreamID]T),
 	}
 }
 
-func (s *outgoingStreamsMap) removeStream(id quic.StreamID) {
+func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap[*Stream] {
+	streamHdr := newOutgoingStreamHeader(webTransportFrameType, sessionID)
+	var streams *outgoingStreamsMap[*Stream]
+	streams = newOutgoingStreamsMap(
+		func() (*Stream, quic.StreamID, error) {
+			qstr, err := conn.OpenStream()
+			if err != nil {
+				return nil, 0, err
+			}
+			id := qstr.StreamID()
+			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+		},
+		func(ctx context.Context) (*Stream, quic.StreamID, error) {
+			qstr, err := conn.OpenStreamSync(ctx)
+			if qstr == nil {
+				return nil, 0, err
+			}
+			id := qstr.StreamID()
+			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, err
+		},
+		func(limit uint64) { queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: limit}) },
+	)
+	return streams
+}
+
+func newOutgoingUniStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap[*SendStream] {
+	streamHdr := newOutgoingStreamHeader(webTransportUniStreamType, sessionID)
+	var streams *outgoingStreamsMap[*SendStream]
+	streams = newOutgoingStreamsMap(
+		func() (*SendStream, quic.StreamID, error) {
+			qstr, err := conn.OpenUniStream()
+			if err != nil {
+				return nil, 0, err
+			}
+			id := qstr.StreamID()
+			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+		},
+		func(ctx context.Context) (*SendStream, quic.StreamID, error) {
+			qstr, err := conn.OpenUniStreamSync(ctx)
+			if qstr == nil {
+				return nil, 0, err
+			}
+			id := qstr.StreamID()
+			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, err
+		},
+		func(limit uint64) { queueCapsule(streamsBlockedUniCapsule{MaximumStreams: limit}) },
+	)
+	return streams
+}
+
+func newOutgoingStreamHeader(streamType uint64, sessionID sessionID) []byte {
+	hdr := make([]byte, 0, 2+quicvarint.Len(uint64(sessionID)))
+	hdr = quicvarint.Append(hdr, streamType)
+	return quicvarint.Append(hdr, uint64(sessionID))
+}
+
+func (s *outgoingStreamsMap[T]) removeStream(id quic.StreamID) {
 	s.mx.Lock()
 	delete(s.m, id)
 	s.mx.Unlock()
 }
 
-func (s *outgoingStreamsMap) addStream(qstr *quic.Stream) *Stream {
-	str := newStream(qstr, s.streamHdr, func() { s.removeStream(qstr.StreamID()) })
-	s.m[qstr.StreamID()] = str.closeWithSession
-	return str
-}
-
-func (s *outgoingStreamsMap) addSendStream(qstr *quic.SendStream) *SendStream {
-	str := newSendStream(qstr, s.uniStreamHdr, func() { s.removeStream(qstr.StreamID()) })
-	s.m[qstr.StreamID()] = str.closeWithSession
-	return str
-}
-
-func (s *outgoingStreamsMap) OpenStream() (*Stream, error) {
+func (s *outgoingStreamsMap[T]) OpenStream() (T, error) {
 	s.mx.Lock()
 
+	var zero T
 	if s.closeErr != nil {
 		s.mx.Unlock()
-		return nil, s.closeErr
+		return zero, s.closeErr
 	}
-	if len(s.bidiLimit.OpenQueue) > 0 {
+	if len(s.openQueue) > 0 {
 		s.mx.Unlock()
-		return nil, &StreamLimitReachedError{}
+		return zero, &StreamLimitReachedError{}
 	}
 
-	if s.bidiLimit.NumStreams >= s.bidiLimit.MaxStreams {
-		sendBlocked := !s.bidiLimit.BlockedSent
-		maxStreams := s.bidiLimit.MaxStreams
+	if s.numStreams >= s.maxStreams {
+		sendBlocked := !s.blockedSent
+		maxStreams := s.maxStreams
 		if sendBlocked {
-			s.bidiLimit.BlockedSent = true
+			s.blockedSent = true
 		}
 		s.mx.Unlock()
 		if sendBlocked {
-			s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
+			s.queueBlocked(maxStreams)
 		}
-		return nil, &StreamLimitReachedError{}
+		return zero, &StreamLimitReachedError{}
 	}
-	s.bidiLimit.NumStreams++
+	s.numStreams++
 
-	qstr, err := s.conn.OpenStream()
+	str, id, err := s.openStream()
 	if err != nil {
-		s.bidiLimit.NumStreams--
-		s.maybeUnblockOpenSync(&s.bidiLimit)
+		s.numStreams--
+		s.maybeUnblockOpenSync()
 		s.mx.Unlock()
-		return nil, err
+		return zero, err
 	}
-	str := s.addStream(qstr)
+	s.m[id] = str
 	s.mx.Unlock()
 	return str, nil
 }
 
-func (s *outgoingStreamsMap) addStreamCtxCancel(cancel context.CancelFunc) (id int) {
+func (s *outgoingStreamsMap[T]) addStreamCtxCancel(cancel context.CancelFunc) (id int) {
 rand:
 	id = rand.Int()
 	if _, ok := s.streamCtxs[id]; ok {
@@ -129,140 +166,63 @@ rand:
 	return id
 }
 
-func (s *outgoingStreamsMap) OpenStreamSync(ctx context.Context) (*Stream, error) {
+func (s *outgoingStreamsMap[T]) OpenStreamSync(ctx context.Context) (T, error) {
 	s.mx.Lock()
+	var zero T
 	if s.closeErr != nil {
 		s.mx.Unlock()
-		return nil, s.closeErr
+		return zero, s.closeErr
 	}
-	if err := s.waitForStreamLimit(ctx, &s.bidiLimit, true); err != nil {
+	if err := s.waitForStreamLimit(ctx); err != nil {
 		s.mx.Unlock()
-		return nil, err
+		return zero, err
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	id := s.addStreamCtxCancel(cancel)
 	s.mx.Unlock()
 
-	qstr, err := s.conn.OpenStreamSync(ctx)
+	str, streamID, err := s.openStreamSync(ctx)
 
 	s.mx.Lock()
 	defer s.mx.Unlock()
 	delete(s.streamCtxs, id)
 
-	if qstr != nil && s.closeErr != nil {
-		qstr.CancelRead(WTSessionGoneErrorCode)
-		qstr.CancelWrite(WTSessionGoneErrorCode)
-		return nil, s.closeErr
+	if str != nil && s.closeErr != nil {
+		str.closeWithSession(s.closeErr)
+		return zero, s.closeErr
 	}
 	if err != nil {
-		if qstr == nil && s.closeErr == nil {
-			s.bidiLimit.NumStreams--
-			s.maybeUnblockOpenSync(&s.bidiLimit)
+		if str == nil && s.closeErr == nil {
+			s.numStreams--
+			s.maybeUnblockOpenSync()
 		}
 		if s.closeErr != nil {
-			return nil, s.closeErr
+			return zero, s.closeErr
 		}
-		return nil, err
+		return zero, err
 	}
-	return s.addStream(qstr), nil
-}
-
-func (s *outgoingStreamsMap) OpenUniStream() (*SendStream, error) {
-	s.mx.Lock()
-
-	if s.closeErr != nil {
-		s.mx.Unlock()
-		return nil, s.closeErr
-	}
-	if len(s.uniLimit.OpenQueue) > 0 {
-		s.mx.Unlock()
-		return nil, &StreamLimitReachedError{}
-	}
-	if s.uniLimit.NumStreams >= s.uniLimit.MaxStreams {
-		sendBlocked := !s.uniLimit.BlockedSent
-		maxStreams := s.uniLimit.MaxStreams
-		if sendBlocked {
-			s.uniLimit.BlockedSent = true
-		}
-		s.mx.Unlock()
-		if sendBlocked {
-			s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
-		}
-		return nil, &StreamLimitReachedError{}
-	}
-	s.uniLimit.NumStreams++
-	qstr, err := s.conn.OpenUniStream()
-	if err != nil {
-		s.uniLimit.NumStreams--
-		s.maybeUnblockOpenSync(&s.uniLimit)
-		s.mx.Unlock()
-		return nil, err
-	}
-	str := s.addSendStream(qstr)
-	s.mx.Unlock()
+	s.m[streamID] = str
 	return str, nil
 }
 
-func (s *outgoingStreamsMap) OpenUniStreamSync(ctx context.Context) (str *SendStream, err error) {
-	s.mx.Lock()
-	if s.closeErr != nil {
-		s.mx.Unlock()
-		return nil, s.closeErr
-	}
-	if err := s.waitForStreamLimit(ctx, &s.uniLimit, false); err != nil {
-		s.mx.Unlock()
-		return nil, err
-	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	id := s.addStreamCtxCancel(cancel)
-	s.mx.Unlock()
-
-	qstr, err := s.conn.OpenUniStreamSync(ctx)
-
-	s.mx.Lock()
-	defer s.mx.Unlock()
-	delete(s.streamCtxs, id)
-
-	if qstr != nil && s.closeErr != nil {
-		qstr.CancelWrite(WTSessionGoneErrorCode)
-		return nil, s.closeErr
-	}
-	if err != nil {
-		if qstr == nil && s.closeErr == nil {
-			s.uniLimit.NumStreams--
-			s.maybeUnblockOpenSync(&s.uniLimit)
-		}
-		if s.closeErr != nil {
-			return nil, s.closeErr
-		}
-		return nil, err
-	}
-	return s.addSendStream(qstr), nil
-}
-
-func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit *outgoingStreamLimit, bidirectional bool) error {
+func (s *outgoingStreamsMap[T]) waitForStreamLimit(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if len(streamLimit.OpenQueue) == 0 && streamLimit.NumStreams < streamLimit.MaxStreams {
-		streamLimit.NumStreams++
+	if len(s.openQueue) == 0 && s.numStreams < s.maxStreams {
+		s.numStreams++
 		return nil
 	}
 
 	waitChan := make(chan struct{}, 1)
-	streamLimit.OpenQueue = append(streamLimit.OpenQueue, waitChan)
+	s.openQueue = append(s.openQueue, waitChan)
 
-	if streamLimit.NumStreams >= streamLimit.MaxStreams && !streamLimit.BlockedSent {
-		streamLimit.BlockedSent = true
-		maxStreams := streamLimit.MaxStreams
+	if s.numStreams >= s.maxStreams && !s.blockedSent {
+		s.blockedSent = true
+		maxStreams := s.maxStreams
 		s.mx.Unlock()
-		if bidirectional {
-			s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
-		} else {
-			s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
-		}
+		s.queueBlocked(maxStreams)
 		s.mx.Lock()
 		if s.closeErr != nil {
 			return s.closeErr
@@ -273,12 +233,12 @@ func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit
 	select {
 	case <-ctx.Done():
 		s.mx.Lock()
-		streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+		s.openQueue = slices.DeleteFunc(s.openQueue, func(c chan struct{}) bool {
 			return c == waitChan
 		})
 		// If we just received a WT_MAX_STREAMS capsule, this might have been the next stream
 		// that could be opened. Make sure we unblock the next OpenStreamSync call.
-		s.maybeUnblockOpenSync(streamLimit)
+		s.maybeUnblockOpenSync()
 		return ctx.Err()
 	case <-waitChan:
 	}
@@ -288,73 +248,61 @@ func (s *outgoingStreamsMap) waitForStreamLimit(ctx context.Context, streamLimit
 		return s.closeErr
 	}
 	if err := ctx.Err(); err != nil {
-		streamLimit.OpenQueue = slices.DeleteFunc(streamLimit.OpenQueue, func(c chan struct{}) bool {
+		s.openQueue = slices.DeleteFunc(s.openQueue, func(c chan struct{}) bool {
 			return c == waitChan
 		})
-		s.maybeUnblockOpenSync(streamLimit)
+		s.maybeUnblockOpenSync()
 		return err
 	}
 
-	streamLimit.NumStreams++
-	streamLimit.OpenQueue = streamLimit.OpenQueue[1:]
-	if len(streamLimit.OpenQueue) > 0 && streamLimit.NumStreams >= streamLimit.MaxStreams {
-		if !streamLimit.BlockedSent {
-			streamLimit.BlockedSent = true
-			maxStreams := streamLimit.MaxStreams
+	s.numStreams++
+	s.openQueue = s.openQueue[1:]
+	if len(s.openQueue) > 0 && s.numStreams >= s.maxStreams {
+		if !s.blockedSent {
+			s.blockedSent = true
+			maxStreams := s.maxStreams
 			s.mx.Unlock()
-			if bidirectional {
-				s.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: maxStreams})
-			} else {
-				s.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: maxStreams})
-			}
+			s.queueBlocked(maxStreams)
 			s.mx.Lock()
 			if s.closeErr != nil {
 				return s.closeErr
 			}
 		}
 	} else {
-		s.maybeUnblockOpenSync(streamLimit)
+		s.maybeUnblockOpenSync()
 	}
 	return nil
 }
 
-func (s *outgoingStreamsMap) UpdateBidiStreamLimit(limit uint64) {
-	s.updateStreamLimit(&s.bidiLimit, limit)
-}
-
-func (s *outgoingStreamsMap) UpdateUniStreamLimit(limit uint64) {
-	s.updateStreamLimit(&s.uniLimit, limit)
-}
-
-func (s *outgoingStreamsMap) updateStreamLimit(streamLimit *outgoingStreamLimit, limit uint64) {
+func (s *outgoingStreamsMap[T]) UpdateStreamLimit(limit uint64) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	if limit <= streamLimit.MaxStreams || s.closeErr != nil {
+	if limit <= s.maxStreams || s.closeErr != nil {
 		return
 	}
-	streamLimit.MaxStreams = limit
-	streamLimit.BlockedSent = false
-	s.maybeUnblockOpenSync(streamLimit)
+	s.maxStreams = limit
+	s.blockedSent = false
+	s.maybeUnblockOpenSync()
 }
 
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream.
-func (s *outgoingStreamsMap) maybeUnblockOpenSync(streamLimit *outgoingStreamLimit) {
-	if len(streamLimit.OpenQueue) == 0 {
+func (s *outgoingStreamsMap[T]) maybeUnblockOpenSync() {
+	if len(s.openQueue) == 0 {
 		return
 	}
-	if streamLimit.NumStreams >= streamLimit.MaxStreams {
+	if s.numStreams >= s.maxStreams {
 		return
 	}
 	// maybeUnblockOpenSync is called both from OpenStreamSync and from UpdateStreamLimit.
 	// It's sufficient to only unblock OpenStreamSync once.
 	select {
-	case streamLimit.OpenQueue[0] <- struct{}{}:
+	case s.openQueue[0] <- struct{}{}:
 	default:
 	}
 }
 
-func (s *outgoingStreamsMap) CloseSession(err error) {
+func (s *outgoingStreamsMap[T]) CloseSession(err error) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
@@ -366,17 +314,13 @@ func (s *outgoingStreamsMap) CloseSession(err error) {
 	for _, cancel := range s.streamCtxs {
 		cancel()
 	}
-	for _, c := range s.bidiLimit.OpenQueue {
+	for _, c := range s.openQueue {
 		close(c)
 	}
-	s.bidiLimit.OpenQueue = nil
-	for _, c := range s.uniLimit.OpenQueue {
-		close(c)
-	}
-	s.uniLimit.OpenQueue = nil
+	s.openQueue = nil
 
-	for _, cl := range s.m {
-		cl(err)
+	for _, str := range s.m {
+		str.closeWithSession(err)
 	}
 	s.m = nil
 }

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -16,10 +16,12 @@ type StreamLimitReachedError struct{}
 
 func (e StreamLimitReachedError) Error() string { return "too many open streams" }
 
-const maxOutgoingStreams = 1 << 60
+const (
+	maxOutgoingStreams = 1 << 60
+	invalidStreamID    = quic.StreamID(-1)
+)
 
 type outgoingStream interface {
-	*Stream | *SendStream
 	closeWithSession(error)
 }
 
@@ -69,11 +71,11 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsul
 		},
 		func(ctx context.Context) (*Stream, quic.StreamID, error) {
 			qstr, err := conn.OpenStreamSync(ctx)
-			if qstr == nil {
-				return nil, 0, err
+			if err != nil {
+				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, err
+			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: limit}) },
 	)
@@ -94,11 +96,11 @@ func newOutgoingUniStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule
 		},
 		func(ctx context.Context) (*SendStream, quic.StreamID, error) {
 			qstr, err := conn.OpenUniStreamSync(ctx)
-			if qstr == nil {
-				return nil, 0, err
+			if err != nil {
+				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, err
+			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedUniCapsule{MaximumStreams: limit}) },
 	)
@@ -188,12 +190,12 @@ func (s *outgoingStreamsMap[T]) OpenStreamSync(ctx context.Context) (T, error) {
 	defer s.mx.Unlock()
 	delete(s.streamCtxs, id)
 
-	if str != nil && s.closeErr != nil {
+	if streamID != invalidStreamID && s.closeErr != nil {
 		str.closeWithSession(s.closeErr)
 		return zero, s.closeErr
 	}
 	if err != nil {
-		if str == nil && s.closeErr == nil {
+		if s.closeErr == nil {
 			s.numStreams--
 			s.maybeUnblockOpenSync()
 		}

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -5,40 +5,39 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T) {
 	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncCloseSession(
-			t,
-			func(m *outgoingStreamsMap) error { _, err := m.OpenStream(); return err },
-			func(m *outgoingStreamsMap) error { _, err := m.OpenStreamSync(context.Background()); return err },
-		)
+		testOutgoingStreamsMapOpenStreamSyncCloseSession(t, newOutgoingBidiStreamsMap)
 	})
 	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncCloseSession(
-			t,
-			func(m *outgoingStreamsMap) error { _, err := m.OpenUniStream(); return err },
-			func(m *outgoingStreamsMap) error { _, err := m.OpenUniStreamSync(context.Background()); return err },
-		)
+		testOutgoingStreamsMapOpenStreamSyncCloseSession(t, newOutgoingUniStreamsMap)
 	})
 }
 
-func testOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T, openStream, openStreamSync func(*outgoingStreamsMap) error) {
+func testOutgoingStreamsMapOpenStreamSyncCloseSession[T outgoingStream](
+	t *testing.T,
+	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
+) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) {
+	streams := newStreams(clientConn, 42, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
 
 	for {
-		if err := openStream(streams); err != nil {
+		if _, err := streams.OpenStream(); err != nil {
 			break
 		}
 	}
 
 	errChan := make(chan error, 1)
-	go func() { errChan <- openStreamSync(streams) }()
+	go func() {
+		_, err := streams.OpenStreamSync(context.Background())
+		errChan <- err
+	}()
 
 	select {
 	case <-errChan:
@@ -59,39 +58,50 @@ func testOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T, openStream, 
 
 func TestOutgoingStreamsMapOpenStreamLimit(t *testing.T) {
 	t.Run("bidirectional", func(t *testing.T) {
-		var capsules []capsule
-		streams := newOutgoingStreamsMap(nil, 42, func(c capsule) { capsules = append(capsules, c) })
-		streams.bidiLimit.MaxStreams = 0
-		_, err := streams.OpenStream()
-		var limitErr *StreamLimitReachedError
-		require.ErrorAs(t, err, &limitErr)
-		require.Equal(t, []capsule{streamsBlockedBidiCapsule{MaximumStreams: 0}}, capsules)
-
-		_, err = streams.OpenStream()
-		require.ErrorAs(t, err, &limitErr)
-		require.Len(t, capsules, 1)
+		testOutgoingStreamsMapOpenStreamLimit(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0})
 	})
-
 	t.Run("unidirectional", func(t *testing.T) {
-		var capsules []capsule
-		streams := newOutgoingStreamsMap(nil, 42, func(c capsule) { capsules = append(capsules, c) })
-		streams.uniLimit.MaxStreams = 0
-		_, err := streams.OpenUniStream()
-		var limitErr *StreamLimitReachedError
-		require.ErrorAs(t, err, &limitErr)
-		require.Equal(t, []capsule{streamsBlockedUniCapsule{MaximumStreams: 0}}, capsules)
-
-		_, err = streams.OpenUniStream()
-		require.ErrorAs(t, err, &limitErr)
-		require.Len(t, capsules, 1)
+		testOutgoingStreamsMapOpenStreamLimit(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0})
 	})
 }
 
+func testOutgoingStreamsMapOpenStreamLimit[T outgoingStream](
+	t *testing.T,
+	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
+	blocked capsule,
+) {
+	var capsules []capsule
+	streams := newStreams(nil, 42, func(c capsule) { capsules = append(capsules, c) })
+	streams.maxStreams = 0
+
+	_, err := streams.OpenStream()
+	var limitErr *StreamLimitReachedError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, []capsule{blocked}, capsules)
+
+	_, err = streams.OpenStream()
+	require.ErrorAs(t, err, &limitErr)
+	require.Len(t, capsules, 1)
+}
+
 func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
+	t.Run("bidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapBlockedCapsules(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0})
+	})
+	t.Run("unidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapBlockedCapsules(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0})
+	})
+}
+
+func testOutgoingStreamsMapBlockedCapsules[T outgoingStream](
+	t *testing.T,
+	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
+	blocked capsule,
+) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
 	capsuleChan := make(chan capsule, 2)
-	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
-	streams.bidiLimit.MaxStreams = 0
+	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
+	streams.maxStreams = 0
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -103,7 +113,7 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 
 	select {
 	case c := <-capsuleChan:
-		require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: 0}, c)
+		require.Equal(t, blocked, c)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for capsule")
 	}
@@ -130,45 +140,40 @@ func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
 	t.Run("bidirectional", func(t *testing.T) {
 		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 			t,
-			func(m *outgoingStreamsMap) error { _, err := m.OpenStream(); return err },
-			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenStreamSync(ctx); return err },
-			(*outgoingStreamsMap).UpdateBidiStreamLimit,
+			newOutgoingBidiStreamsMap,
 			streamsBlockedBidiCapsule{MaximumStreams: 0},
 			streamsBlockedBidiCapsule{MaximumStreams: 1},
 		)
 	})
-
 	t.Run("unidirectional", func(t *testing.T) {
 		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 			t,
-			func(m *outgoingStreamsMap) error { _, err := m.OpenUniStream(); return err },
-			func(m *outgoingStreamsMap, ctx context.Context) error { _, err := m.OpenUniStreamSync(ctx); return err },
-			(*outgoingStreamsMap).UpdateUniStreamLimit,
+			newOutgoingUniStreamsMap,
 			streamsBlockedUniCapsule{MaximumStreams: 0},
 			streamsBlockedUniCapsule{MaximumStreams: 1},
 		)
 	})
 }
 
-func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
+func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate[T outgoingStream](
 	t *testing.T,
-	openStream func(*outgoingStreamsMap) error,
-	openStreamSync func(*outgoingStreamsMap, context.Context) error,
-	updateLimit func(*outgoingStreamsMap, uint64),
+	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
 	initialBlocked capsule,
 	nextBlocked capsule,
 ) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
 	capsuleChan := make(chan capsule, 2)
-	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
-	streams.bidiLimit.MaxStreams = 0
-	streams.uniLimit.MaxStreams = 0
+	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
+	streams.maxStreams = 0
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	errChan := make(chan error, 1)
-	go func() { errChan <- openStreamSync(streams, ctx) }()
+	go func() {
+		_, err := streams.OpenStreamSync(ctx)
+		errChan <- err
+	}()
 
 	select {
 	case <-errChan:
@@ -182,7 +187,7 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 		t.Fatal("timeout waiting for capsule")
 	}
 
-	updateLimit(streams, 1)
+	streams.UpdateStreamLimit(1)
 
 	select {
 	case err := <-errChan:
@@ -196,7 +201,7 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 	default:
 	}
 
-	err := openStream(streams)
+	_, err := streams.OpenStream()
 	var limitErr *StreamLimitReachedError
 	require.ErrorAs(t, err, &limitErr)
 	select {
@@ -206,7 +211,10 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 		t.Fatal("timeout waiting for capsule")
 	}
 
-	go func() { errChan <- openStreamSync(streams, ctx) }()
+	go func() {
+		_, err := streams.OpenStreamSync(ctx)
+		errChan <- err
+	}()
 	select {
 	case <-errChan:
 		t.Fatal("should not have opened stream")
@@ -215,11 +223,29 @@ func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
 }
 
 func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
+	t.Run("bidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapOpenStreamSyncOrder(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0}, func(limit uint64) capsule {
+			return streamsBlockedBidiCapsule{MaximumStreams: limit}
+		})
+	})
+	t.Run("unidirectional", func(t *testing.T) {
+		testOutgoingStreamsMapOpenStreamSyncOrder(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0}, func(limit uint64) capsule {
+			return streamsBlockedUniCapsule{MaximumStreams: limit}
+		})
+	})
+}
+
+func testOutgoingStreamsMapOpenStreamSyncOrder[T outgoingStream](
+	t *testing.T,
+	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
+	initialBlocked capsule,
+	blockedAt func(uint64) capsule,
+) {
 	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
 	const numStreams = 16
 	capsuleChan := make(chan capsule, numStreams)
-	streams := newOutgoingStreamsMap(clientConn, 42, func(c capsule) { capsuleChan <- c })
-	streams.bidiLimit.MaxStreams = 0
+	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
+	streams.maxStreams = 0
 
 	type result struct {
 		index int
@@ -234,12 +260,12 @@ func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 		require.Eventually(t, func() bool {
 			streams.mx.Lock()
 			defer streams.mx.Unlock()
-			return len(streams.bidiLimit.OpenQueue) == i+1
+			return len(streams.openQueue) == i+1
 		}, time.Second, scaleDuration(time.Millisecond))
 	}
 	select {
 	case c := <-capsuleChan:
-		require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: 0}, c)
+		require.Equal(t, initialBlocked, c)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for capsule")
 	}
@@ -250,7 +276,7 @@ func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 	}
 
 	for i := range numStreams {
-		streams.UpdateBidiStreamLimit(uint64(i + 1))
+		streams.UpdateStreamLimit(uint64(i + 1))
 		select {
 		case r := <-resultChan:
 			require.NoError(t, r.err)
@@ -268,7 +294,7 @@ func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
 		}
 		select {
 		case c := <-capsuleChan:
-			require.Equal(t, streamsBlockedBidiCapsule{MaximumStreams: uint64(i + 1)}, c)
+			require.Equal(t, blockedAt(uint64(i+1)), c)
 		case <-time.After(time.Second):
 			t.Fatal("timeout waiting for capsule")
 		}

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -2,6 +2,7 @@ package webtransport
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,40 +10,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutgoingStreamsMapOpenStreamSyncCloseSession(t *testing.T) {
-	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncCloseSession(t, newOutgoingBidiStreamsMap)
-	})
-	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncCloseSession(t, newOutgoingUniStreamsMap)
-	})
-}
+type outgoingStreamForTests struct{}
 
-func testOutgoingStreamsMapOpenStreamSyncCloseSession[T outgoingStream](
-	t *testing.T,
-	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
-) {
-	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newStreams(clientConn, 42, func(c capsule) {
-		t.Fatalf("unexpected capsule: %#v", c)
-	})
+func (*outgoingStreamForTests) closeWithSession(error) {}
 
-	for {
-		if _, err := streams.OpenStream(); err != nil {
-			break
-		}
+func TestOutgoingStreamsMapOpenStreamSyncClose(t *testing.T) {
+	var nextStreamID atomic.Uint64
+	openStream := func() (*outgoingStreamForTests, quic.StreamID, error) {
+		return &outgoingStreamForTests{}, quic.StreamID(nextStreamID.Add(1)), nil
 	}
+	openStreamSyncCalled := make(chan struct{}, 1)
+	streams := newOutgoingStreamsMap(
+		openStream,
+		func(ctx context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
+			openStreamSyncCalled <- struct{}{}
+			<-ctx.Done()
+			return nil, invalidStreamID, ctx.Err()
+		},
+		func(uint64) {},
+	)
+	streams.maxStreams = 1
 
 	errChan := make(chan error, 1)
 	go func() {
 		_, err := streams.OpenStreamSync(context.Background())
 		errChan <- err
 	}()
-
 	select {
-	case <-errChan:
-		t.Fatal("should not have opened stream")
-	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	case <-openStreamSyncCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for quic OpenStreamSync call")
 	}
 
 	sessionErr := &SessionError{ErrorCode: 1337, Message: "closing"}
@@ -56,74 +53,53 @@ func testOutgoingStreamsMapOpenStreamSyncCloseSession[T outgoingStream](
 	}
 }
 
-func TestOutgoingStreamsMapOpenStreamLimit(t *testing.T) {
-	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamLimit(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0})
-	})
-	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamLimit(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0})
-	})
-}
-
-func testOutgoingStreamsMapOpenStreamLimit[T outgoingStream](
-	t *testing.T,
-	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
-	blocked capsule,
-) {
-	var capsules []capsule
-	streams := newStreams(nil, 42, func(c capsule) { capsules = append(capsules, c) })
-	streams.maxStreams = 0
-
-	_, err := streams.OpenStream()
-	var limitErr *StreamLimitReachedError
-	require.ErrorAs(t, err, &limitErr)
-	require.Equal(t, []capsule{blocked}, capsules)
-
-	_, err = streams.OpenStream()
-	require.ErrorAs(t, err, &limitErr)
-	require.Len(t, capsules, 1)
-}
-
-func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
-	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapBlockedCapsules(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0})
-	})
-	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapBlockedCapsules(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0})
-	})
-}
-
-func testOutgoingStreamsMapBlockedCapsules[T outgoingStream](
-	t *testing.T,
-	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
-	blocked capsule,
-) {
-	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	capsuleChan := make(chan capsule, 2)
-	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
+func TestOutgoingStreamsMapOpenStreamSyncBlocksAtLimit(t *testing.T) {
+	var nextStreamID atomic.Uint64
+	//nolint:unparam // ignore unused error return value
+	openStream := func() (*outgoingStreamForTests, quic.StreamID, error) {
+		return &outgoingStreamForTests{}, quic.StreamID(nextStreamID.Add(1)), nil
+	}
+	blocked := make(chan uint64, 10)
+	openStreamSyncCalled := make(chan struct{}, 1)
+	streams := newOutgoingStreamsMap(
+		openStream,
+		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
+			openStreamSyncCalled <- struct{}{}
+			return openStream()
+		},
+		func(limit uint64) { blocked <- limit },
+	)
 	streams.maxStreams = 0
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	errChan := make(chan error, 1)
 	go func() {
 		_, err := streams.OpenStreamSync(ctx)
 		errChan <- err
 	}()
-
 	select {
-	case c := <-capsuleChan:
-		require.Equal(t, blocked, c)
+	case limit := <-blocked:
+		require.Equal(t, uint64(0), limit)
 	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for capsule")
+		t.Fatal("timeout waiting for blocked capsule")
+	}
+	select {
+	case err := <-errChan:
+		t.Fatalf("OpenStreamSync returned while blocked: %v", err)
+	default:
+	}
+	select {
+	case <-openStreamSyncCalled:
+		t.Fatal("quic OpenStreamSync called while blocked by WebTransport stream limit")
+	default:
 	}
 
 	_, err := streams.OpenStream()
 	var limitErr *StreamLimitReachedError
 	require.ErrorAs(t, err, &limitErr)
 	select {
-	case c := <-capsuleChan:
-		t.Fatalf("unexpected capsule: %#v", c)
+	case limit := <-blocked:
+		t.Fatalf("unexpected blocked capsule for limit %d", limit)
 	default:
 	}
 
@@ -136,167 +112,156 @@ func testOutgoingStreamsMapBlockedCapsules[T outgoingStream](
 	}
 }
 
-func TestOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(t *testing.T) {
-	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
-			t,
-			newOutgoingBidiStreamsMap,
-			streamsBlockedBidiCapsule{MaximumStreams: 0},
-			streamsBlockedBidiCapsule{MaximumStreams: 1},
-		)
-	})
-	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate(
-			t,
-			newOutgoingUniStreamsMap,
-			streamsBlockedUniCapsule{MaximumStreams: 0},
-			streamsBlockedUniCapsule{MaximumStreams: 1},
-		)
-	})
-}
-
-func testOutgoingStreamsMapOpenStreamSyncBlockedUntilLimitUpdate[T outgoingStream](
-	t *testing.T,
-	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
-	initialBlocked capsule,
-	nextBlocked capsule,
-) {
-	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	capsuleChan := make(chan capsule, 2)
-	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
-	streams.maxStreams = 0
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	errChan := make(chan error, 1)
-	go func() {
-		_, err := streams.OpenStreamSync(ctx)
-		errChan <- err
-	}()
-
-	select {
-	case <-errChan:
-		t.Fatal("should not have opened stream")
-	case <-time.After(scaleDuration(10 * time.Millisecond)):
+func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
+	var nextStreamID atomic.Uint64
+	//nolint:unparam // ignore unused error return value
+	openStream := func() (*outgoingStreamForTests, quic.StreamID, error) {
+		return &outgoingStreamForTests{}, quic.StreamID(nextStreamID.Add(1)), nil
 	}
-	select {
-	case c := <-capsuleChan:
-		require.Equal(t, initialBlocked, c)
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for capsule")
-	}
-
-	streams.UpdateStreamLimit(1)
-
-	select {
-	case err := <-errChan:
+	blocked := make(chan uint64, 10)
+	openStreamSyncCalled := make(chan quic.StreamID, 10)
+	releaseOpenStreamSync := make(chan struct{})
+	streams := newOutgoingStreamsMap(
+		openStream,
+		func(ctx context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
+			str, id, err := openStream()
+			if err != nil {
+				return nil, invalidStreamID, err
+			}
+			openStreamSyncCalled <- id
+			select {
+			case <-releaseOpenStreamSync:
+				return str, id, nil
+			case <-ctx.Done():
+				return nil, invalidStreamID, ctx.Err()
+			}
+		},
+		func(limit uint64) { blocked <- limit },
+	)
+	streams.maxStreams = 3
+	for range 3 {
+		_, err := streams.OpenStream()
 		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
 	}
-	select {
-	case c := <-capsuleChan:
-		t.Fatalf("unexpected capsule: %#v", c)
-	default:
-	}
-
 	_, err := streams.OpenStream()
 	var limitErr *StreamLimitReachedError
 	require.ErrorAs(t, err, &limitErr)
 	select {
-	case c := <-capsuleChan:
-		require.Equal(t, nextBlocked, c)
+	case limit := <-blocked:
+		require.Equal(t, uint64(3), limit)
 	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for capsule")
+		t.Fatal("timeout waiting for blocked capsule")
 	}
 
-	go func() {
-		_, err := streams.OpenStreamSync(ctx)
-		errChan <- err
-	}()
+	// further calls to OpenStream don't trigger new blocked capsules
+	for range 5 {
+		_, err = streams.OpenStream()
+		require.ErrorAs(t, err, &limitErr)
+	}
 	select {
-	case <-errChan:
-		t.Fatal("should not have opened stream")
-	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	case limit := <-blocked:
+		t.Fatalf("unexpected blocked capsule for limit %d", limit)
+	default:
 	}
-}
 
-func TestOutgoingStreamsMapOpenStreamSyncOrder(t *testing.T) {
-	t.Run("bidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncOrder(t, newOutgoingBidiStreamsMap, streamsBlockedBidiCapsule{MaximumStreams: 0}, func(limit uint64) capsule {
-			return streamsBlockedBidiCapsule{MaximumStreams: limit}
-		})
-	})
-	t.Run("unidirectional", func(t *testing.T) {
-		testOutgoingStreamsMapOpenStreamSyncOrder(t, newOutgoingUniStreamsMap, streamsBlockedUniCapsule{MaximumStreams: 0}, func(limit uint64) capsule {
-			return streamsBlockedUniCapsule{MaximumStreams: limit}
-		})
-	})
-}
-
-func testOutgoingStreamsMapOpenStreamSyncOrder[T outgoingStream](
-	t *testing.T,
-	newStreams func(*quic.Conn, sessionID, func(capsule)) *outgoingStreamsMap[T],
-	initialBlocked capsule,
-	blockedAt func(uint64) capsule,
-) {
-	clientConn, _ := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	const numStreams = 16
-	capsuleChan := make(chan capsule, numStreams)
-	streams := newStreams(clientConn, 42, func(c capsule) { capsuleChan <- c })
-	streams.maxStreams = 0
-
-	type result struct {
-		index int
-		err   error
-	}
-	resultChan := make(chan result, numStreams)
-	for i := range numStreams {
+	errChan := make(chan error, 3)
+	for range 3 {
 		go func() {
 			_, err := streams.OpenStreamSync(context.Background())
-			resultChan <- result{index: i, err: err}
+			errChan <- err
 		}()
-		require.Eventually(t, func() bool {
-			streams.mx.Lock()
-			defer streams.mx.Unlock()
-			return len(streams.openQueue) == i+1
-		}, time.Second, scaleDuration(time.Millisecond))
 	}
 	select {
-	case c := <-capsuleChan:
-		require.Equal(t, initialBlocked, c)
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for capsule")
+	case limit := <-blocked:
+		t.Fatalf("unexpected blocked capsule for limit %d", limit)
+	default:
 	}
 	select {
-	case c := <-capsuleChan:
-		t.Fatalf("unexpected capsule: %#v", c)
-	case <-time.After(scaleDuration(10 * time.Millisecond)):
+	case err := <-errChan:
+		t.Fatalf("OpenStreamSync returned while blocked: %v", err)
+	default:
 	}
 
-	for i := range numStreams {
-		streams.UpdateStreamLimit(uint64(i + 1))
+	// allow 2 more streams
+	streams.UpdateStreamLimit(5)
+	for range 2 {
 		select {
-		case r := <-resultChan:
-			require.NoError(t, r.err)
-			require.Equal(t, i, r.index)
+		case <-openStreamSyncCalled:
 		case <-time.After(time.Second):
-			t.Fatal("timeout")
+			t.Fatal("timeout waiting for quic OpenStreamSync call")
 		}
-		if i == numStreams-1 {
-			select {
-			case c := <-capsuleChan:
-				t.Fatalf("unexpected capsule: %#v", c)
-			default:
-			}
-			continue
-		}
+	}
+	select {
+	case limit := <-blocked:
+		require.Equal(t, uint64(5), limit)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for blocked capsule")
+	}
+	select {
+	case id := <-openStreamSyncCalled:
+		t.Fatalf("too many quic OpenStreamSync calls reached: %d", id)
+	default:
+	}
+	select {
+	case err := <-errChan:
+		t.Fatalf("OpenStreamSync returned while quic OpenStreamSync was blocked: %v", err)
+	default:
+	}
+
+	streams.UpdateStreamLimit(6)
+	select {
+	case <-openStreamSyncCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for quic OpenStreamSync call")
+	}
+	select {
+	case limit := <-blocked:
+		t.Fatalf("unexpected blocked capsule for limit %d", limit)
+	default:
+	}
+	select {
+	case err := <-errChan:
+		t.Fatalf("OpenStreamSync returned while quic OpenStreamSync was blocked: %v", err)
+	default:
+	}
+
+	close(releaseOpenStreamSync)
+	for range 3 {
 		select {
-		case c := <-capsuleChan:
-			require.Equal(t, blockedAt(uint64(i+1)), c)
+		case err := <-errChan:
+			require.NoError(t, err)
 		case <-time.After(time.Second):
-			t.Fatal("timeout waiting for capsule")
+			t.Fatal("timeout waiting for stream")
 		}
+	}
+}
+
+func TestOutgoingStreamsMapQueueBlockedCanCloseSession(t *testing.T) {
+	var nextStreamID atomic.Uint64
+	//nolint:unparam // ignore unused error return value
+	openStream := func() (*outgoingStreamForTests, quic.StreamID, error) {
+		return &outgoingStreamForTests{}, quic.StreamID(nextStreamID.Add(1)), nil
+	}
+	sessionErr := &SessionError{ErrorCode: 1337, Message: "closing"}
+	var streams *outgoingStreamsMap[*outgoingStreamForTests]
+	streams = newOutgoingStreamsMap(
+		openStream,
+		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) { return openStream() },
+		func(uint64) { streams.CloseSession(sessionErr) },
+	)
+	streams.maxStreams = 0
+
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := streams.OpenStream()
+		errChan <- err
+	}()
+
+	select {
+	case err := <-errChan:
+		var limitErr *StreamLimitReachedError
+		require.ErrorAs(t, err, &limitErr)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
 	}
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Make `outgoingStreamsMap` generic to split bidirectional and unidirectional stream management
- Refactors `outgoingStreamsMap` in [streams_map_outgoing.go](https://github.com/quic-go/webtransport-go/pull/307/files#diff-c615463dd5462bd1b530fa8c6fa108413a258c0d8c7f268fd31d44c8d371ab33) into a generic type parameterized over stream types satisfying a new `outgoingStream` interface.
- Replaces the single combined map with two separate instances: `outgoingStreams` for bidirectional (`*Stream`) and `outgoingUniStreams` for unidirectional (`*SendStream`) streams, each created via dedicated constructors `newOutgoingBidiStreamsMap` and `newOutgoingUniStreamsMap`.
- Unified limit tracking (previously split bidi/uni fields) into a single set of counters per map instance, with stream creation and blocked-capsule signaling injected as function fields.
- `CloseSession` now closes streams by calling their `closeWithSession` method rather than invoking stored close functions; `OpenStreamSync` also uses this path when the session closes after a stream is opened.
- Risk: `session.closeWithError` must now call `CloseSession` on both maps; missing this for unidirectional streams was a bug that this PR fixes.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4738a21.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->