### PR TITLE
ci: remove unneeded staticcheck rule for quic.ConnectionTracing{ID, Key}

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,9 +33,6 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019:.+quic\.ConnectionTracing(ID|Key)'
-      - linters:
-          - staticcheck
         path: _test\.go
         text: 'SA1029:' # inappropriate key in call to context.WithValue
 formatters:


### PR DESCRIPTION
We moved to the new quic-go API in the last release, and we're not relying on deprecated types anymore.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove outdated staticcheck exclusion for `quic.ConnectionTracing{ID,Key}` in CI config
> Updates [.golangci.yml](https://github.com/quic-go/webtransport-go/pull/308/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9) to drop the now-unneeded `SA1019` exclusion for `quic.ConnectionTracingID` and `quic.ConnectionTracingKey`, and adds a new `SA1029` exclusion scoped to `_test.go` files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd3faf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->