### PR TITLE
use a generic implementation for the incoming streams map

### DIFF
--- a/session.go
+++ b/session.go
@@ -76,8 +76,8 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		applicationProtocol: applicationProtocol,
 		ctx:                 ctx,
 		capsuleQueueUpdated: make(chan struct{}, 1),
-		incomingStreams:     newIncomingStreamsMap[*Stream](ctx),
-		incomingUniStreams:  newIncomingStreamsMap[*ReceiveStream](ctx),
+		incomingStreams:     newIncomingStreamsMap[*Stream](),
+		incomingUniStreams:  newIncomingStreamsMap[*ReceiveStream](),
 	}
 	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, c.queueCapsule)
 	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, c.queueCapsule)

--- a/session.go
+++ b/session.go
@@ -53,7 +53,8 @@ type Session struct {
 	pendingCloseCapsule *closeSessionCapsule
 	capsuleQueueUpdated chan struct{}
 
-	incomingStreams    incomingStreamsMap
+	incomingStreams    *incomingStreamsMap[*Stream]
+	incomingUniStreams *incomingStreamsMap[*ReceiveStream]
 	outgoingStreams    *outgoingStreamsMap[*Stream]
 	outgoingUniStreams *outgoingStreamsMap[*SendStream]
 }
@@ -75,7 +76,8 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		applicationProtocol: applicationProtocol,
 		ctx:                 ctx,
 		capsuleQueueUpdated: make(chan struct{}, 1),
-		incomingStreams:     *newIncomingStreamsMap(ctx),
+		incomingStreams:     newIncomingStreamsMap[*Stream](ctx),
+		incomingUniStreams:  newIncomingStreamsMap[*ReceiveStream](ctx),
 	}
 	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, c.queueCapsule)
 	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, c.queueCapsule)
@@ -189,12 +191,14 @@ func (s *Session) queueCapsule(c capsule) {
 
 // addIncomingStream adds a bidirectional stream that the remote peer opened
 func (s *Session) addIncomingStream(qstr *quic.Stream) {
-	s.incomingStreams.AddStream(qstr)
+	id := qstr.StreamID()
+	s.incomingStreams.addStream(id, newStream(qstr, nil, func() { s.incomingStreams.removeStream(id) }))
 }
 
 // addIncomingUniStream adds a unidirectional stream that the remote peer opened
 func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
-	s.incomingStreams.AddUniStream(qstr)
+	id := qstr.StreamID()
+	s.incomingUniStreams.addStream(id, newReceiveStream(qstr, func() { s.incomingUniStreams.removeStream(id) }))
 }
 
 // Context returns a context that is closed when the session is closed.
@@ -207,7 +211,7 @@ func (s *Session) AcceptStream(ctx context.Context) (*Stream, error) {
 }
 
 func (s *Session) AcceptUniStream(ctx context.Context) (*ReceiveStream, error) {
-	return s.incomingStreams.AcceptUniStream(ctx)
+	return s.incomingUniStreams.AcceptStream(ctx)
 }
 
 func (s *Session) OpenStream() (*Stream, error) {
@@ -320,6 +324,7 @@ func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsu
 	s.outgoingStreams.CloseSession(closeErr)
 	s.outgoingUniStreams.CloseSession(closeErr)
 	s.incomingStreams.CloseSession(closeErr)
+	s.incomingUniStreams.CloseSession(closeErr)
 
 	if closeCapsule != nil {
 		s.capsuleQueueMx.Lock()

--- a/stream_test.go
+++ b/stream_test.go
@@ -206,11 +206,9 @@ func TestReceiveStreamSessionGone(t *testing.T) {
 func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newIncomingStreamsMap(context.Background())
+	sm := newIncomingStreamsMap[*ReceiveStream](context.Background())
 	str := newReceiveStream(recvStr, func() { sm.removeStream(recvStr.StreamID()) })
-	sm.mx.Lock()
-	sm.m[recvStr.StreamID()] = str.closeWithSession
-	sm.mx.Unlock()
+	sm.addStream(recvStr.StreamID(), str)
 
 	// start reading
 	errChan := make(chan error, 1)

--- a/stream_test.go
+++ b/stream_test.go
@@ -206,7 +206,7 @@ func TestReceiveStreamSessionGone(t *testing.T) {
 func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newIncomingStreamsMap[*ReceiveStream](context.Background())
+	sm := newIncomingStreamsMap[*ReceiveStream]()
 	str := newReceiveStream(recvStr, func() { sm.removeStream(recvStr.StreamID()) })
 	sm.addStream(recvStr.StreamID(), str)
 

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -35,84 +35,73 @@ func (q *acceptQueue[T]) add(str T) {
 	}
 }
 
-func (q *acceptQueue[T]) next() T {
+func (q *acceptQueue[T]) next() (T, bool) {
 	q.mx.Lock()
 	defer q.mx.Unlock()
 
 	if len(q.queue) == 0 {
-		return *new(T)
+		return *new(T), false
 	}
 	str := q.queue[0]
 	q.queue = q.queue[1:]
-	return str
+	return str, true
 }
 
-type incomingStreamsMap struct {
+type incomingStream interface {
+	*Stream | *ReceiveStream
+	closeWithSession(error)
+}
+
+type incomingStreamsMap[T incomingStream] struct {
 	ctx context.Context
 
-	bidiAcceptQueue acceptQueue[*Stream]
-	uniAcceptQueue  acceptQueue[*ReceiveStream]
+	acceptQueue acceptQueue[T]
 
 	mx       sync.Mutex
 	closeErr error
-	m        map[quic.StreamID]func(error)
+	m        map[quic.StreamID]T
 }
 
-func newIncomingStreamsMap(ctx context.Context) *incomingStreamsMap {
-	return &incomingStreamsMap{
-		ctx:             ctx,
-		bidiAcceptQueue: *newAcceptQueue[*Stream](),
-		uniAcceptQueue:  *newAcceptQueue[*ReceiveStream](),
-		m:               make(map[quic.StreamID]func(error)),
+func newIncomingStreamsMap[T incomingStream](ctx context.Context) *incomingStreamsMap[T] {
+	return &incomingStreamsMap[T]{
+		ctx:         ctx,
+		acceptQueue: *newAcceptQueue[T](),
+		m:           make(map[quic.StreamID]T),
 	}
 }
 
-func (s *incomingStreamsMap) AddStream(qstr *quic.Stream) {
+func (s *incomingStreamsMap[T]) addStream(id quic.StreamID, str T) {
 	s.mx.Lock()
 	if s.closeErr != nil {
+		closeErr := s.closeErr
 		s.mx.Unlock()
-		qstr.CancelRead(WTSessionGoneErrorCode)
-		qstr.CancelWrite(WTSessionGoneErrorCode)
+		str.closeWithSession(closeErr)
 		return
 	}
-	str := newStream(qstr, nil, func() { s.removeStream(qstr.StreamID()) })
-	s.m[qstr.StreamID()] = str.closeWithSession
+	s.m[id] = str
 	s.mx.Unlock()
 
-	s.bidiAcceptQueue.add(str)
+	s.acceptQueue.add(str)
 }
 
-func (s *incomingStreamsMap) AddUniStream(qstr *quic.ReceiveStream) {
-	s.mx.Lock()
-	if s.closeErr != nil {
-		s.mx.Unlock()
-		qstr.CancelRead(WTSessionGoneErrorCode)
-		return
-	}
-	str := newReceiveStream(qstr, func() { s.removeStream(qstr.StreamID()) })
-	s.m[qstr.StreamID()] = str.closeWithSession
-	s.mx.Unlock()
-
-	s.uniAcceptQueue.add(str)
-}
-
-func (s *incomingStreamsMap) removeStream(id quic.StreamID) {
+func (s *incomingStreamsMap[T]) removeStream(id quic.StreamID) {
 	s.mx.Lock()
 	delete(s.m, id)
 	s.mx.Unlock()
 }
 
-func (s *incomingStreamsMap) AcceptStream(ctx context.Context) (*Stream, error) {
+func (s *incomingStreamsMap[T]) AcceptStream(ctx context.Context) (T, error) {
 	s.mx.Lock()
 	closeErr := s.closeErr
 	s.mx.Unlock()
+	var zero T
 	if closeErr != nil {
-		return nil, closeErr
+		return zero, closeErr
 	}
 
 	for {
 		// If there's a stream in the accept queue, return it immediately.
-		if str := s.bidiAcceptQueue.next(); str != nil {
+		if str, ok := s.acceptQueue.next(); ok {
 			return str, nil
 		}
 		// No stream in the accept queue. Wait until we accept one.
@@ -121,42 +110,15 @@ func (s *incomingStreamsMap) AcceptStream(ctx context.Context) (*Stream, error) 
 			s.mx.Lock()
 			closeErr := s.closeErr
 			s.mx.Unlock()
-			return nil, closeErr
+			return zero, closeErr
 		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-s.bidiAcceptQueue.c:
+			return zero, ctx.Err()
+		case <-s.acceptQueue.c:
 		}
 	}
 }
 
-func (s *incomingStreamsMap) AcceptUniStream(ctx context.Context) (*ReceiveStream, error) {
-	s.mx.Lock()
-	closeErr := s.closeErr
-	s.mx.Unlock()
-	if closeErr != nil {
-		return nil, closeErr
-	}
-
-	for {
-		// If there's a stream in the accept queue, return it immediately.
-		if str := s.uniAcceptQueue.next(); str != nil {
-			return str, nil
-		}
-		// No stream in the accept queue. Wait until we accept one.
-		select {
-		case <-s.ctx.Done():
-			s.mx.Lock()
-			closeErr := s.closeErr
-			s.mx.Unlock()
-			return nil, closeErr
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-s.uniAcceptQueue.c:
-		}
-	}
-}
-
-func (s *incomingStreamsMap) CloseSession(err error) {
+func (s *incomingStreamsMap[T]) CloseSession(err error) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
@@ -165,8 +127,8 @@ func (s *incomingStreamsMap) CloseSession(err error) {
 	}
 	s.closeErr = err
 
-	for _, cl := range s.m {
-		cl(err)
+	for _, str := range s.m {
+		str.closeWithSession(err)
 	}
 	s.m = nil
 }

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -53,18 +53,20 @@ type incomingStream interface {
 }
 
 type incomingStreamsMap[T incomingStream] struct {
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelCauseFunc
 
 	acceptQueue acceptQueue[T]
 
-	mx       sync.Mutex
-	closeErr error
-	m        map[quic.StreamID]T
+	mx sync.Mutex
+	m  map[quic.StreamID]T
 }
 
-func newIncomingStreamsMap[T incomingStream](ctx context.Context) *incomingStreamsMap[T] {
+func newIncomingStreamsMap[T incomingStream]() *incomingStreamsMap[T] {
+	ctx, cancel := context.WithCancelCause(context.Background())
 	return &incomingStreamsMap[T]{
 		ctx:         ctx,
+		cancel:      cancel,
 		acceptQueue: *newAcceptQueue[T](),
 		m:           make(map[quic.StreamID]T),
 	}
@@ -72,8 +74,7 @@ func newIncomingStreamsMap[T incomingStream](ctx context.Context) *incomingStrea
 
 func (s *incomingStreamsMap[T]) addStream(id quic.StreamID, str T) {
 	s.mx.Lock()
-	if s.closeErr != nil {
-		closeErr := s.closeErr
+	if closeErr := context.Cause(s.ctx); closeErr != nil {
 		s.mx.Unlock()
 		str.closeWithSession(closeErr)
 		return
@@ -91,11 +92,8 @@ func (s *incomingStreamsMap[T]) removeStream(id quic.StreamID) {
 }
 
 func (s *incomingStreamsMap[T]) AcceptStream(ctx context.Context) (T, error) {
-	s.mx.Lock()
-	closeErr := s.closeErr
-	s.mx.Unlock()
 	var zero T
-	if closeErr != nil {
+	if closeErr := context.Cause(s.ctx); closeErr != nil {
 		return zero, closeErr
 	}
 
@@ -107,10 +105,7 @@ func (s *incomingStreamsMap[T]) AcceptStream(ctx context.Context) (T, error) {
 		// No stream in the accept queue. Wait until we accept one.
 		select {
 		case <-s.ctx.Done():
-			s.mx.Lock()
-			closeErr := s.closeErr
-			s.mx.Unlock()
-			return zero, closeErr
+			return zero, context.Cause(s.ctx)
 		case <-ctx.Done():
 			return zero, ctx.Err()
 		case <-s.acceptQueue.c:
@@ -122,10 +117,10 @@ func (s *incomingStreamsMap[T]) CloseSession(err error) {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	if s.closeErr != nil {
+	if context.Cause(s.ctx) != nil {
 		return
 	}
-	s.closeErr = err
+	s.cancel(err)
 
 	for _, str := range s.m {
 		str.closeWithSession(err)

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -12,8 +12,8 @@ import (
 func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	ctx := context.Background()
 	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newIncomingStreamsMap[*Stream](ctx)
-	uniStreams := newIncomingStreamsMap[*ReceiveStream](ctx)
+	streams := newIncomingStreamsMap[*Stream]()
+	uniStreams := newIncomingStreamsMap[*ReceiveStream]()
 
 	serverStr, err := serverConn.OpenStream()
 	require.NoError(t, err)
@@ -68,6 +68,25 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 			context.Cause(serverUniStr.Context()),
 			&quic.StreamError{Remote: true, StreamID: serverUniStr.StreamID(), ErrorCode: WTSessionGoneErrorCode},
 		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestIncomingStreamsMapCloseSessionUnblocksAcceptStream(t *testing.T) {
+	streams := newIncomingStreamsMap[*Stream]()
+	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
+
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := streams.AcceptStream(context.Background())
+		errChan <- err
+	}()
+
+	streams.CloseSession(sessionErr)
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, sessionErr)
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	}

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -12,7 +12,8 @@ import (
 func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	ctx := context.Background()
 	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newIncomingStreamsMap(ctx)
+	streams := newIncomingStreamsMap[*Stream](ctx)
+	uniStreams := newIncomingStreamsMap[*ReceiveStream](ctx)
 
 	serverStr, err := serverConn.OpenStream()
 	require.NoError(t, err)
@@ -20,7 +21,8 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	require.NoError(t, err)
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
-	streams.AddStream(clientStr)
+	streamID := clientStr.StreamID()
+	streams.addStream(streamID, newStream(clientStr, nil, func() { streams.removeStream(streamID) }))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -28,6 +30,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 
 	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
 	streams.CloseSession(sessionErr)
+	uniStreams.CloseSession(sessionErr)
 	_, err = streams.AcceptStream(ctx)
 	require.ErrorIs(t, err, sessionErr)
 
@@ -37,7 +40,8 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	require.NoError(t, err)
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
-	streams.AddStream(clientStr)
+	streamID = clientStr.StreamID()
+	streams.addStream(streamID, newStream(clientStr, nil, func() { streams.removeStream(streamID) }))
 
 	select {
 	case <-serverStr.Context().Done():
@@ -55,7 +59,8 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	require.NoError(t, err)
 	clientUniStr, err := clientConn.AcceptUniStream(ctx)
 	require.NoError(t, err)
-	streams.AddUniStream(clientUniStr)
+	uniStreamID := clientUniStr.StreamID()
+	uniStreams.addStream(uniStreamID, newReceiveStream(clientUniStr, func() { uniStreams.removeStream(uniStreamID) }))
 
 	select {
 	case <-serverUniStr.Context().Done():


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace incoming streams map with a generic `incomingStreamsMap[T]` implementation
- Refactors [streams_map_incoming.go](https://github.com/quic-go/webtransport-go/pull/309/files#diff-abe44939d50a8c49cf8b8c0873c58ec6f888fdd5e51e15c45e9109c5ea809f27) to use a single generic `incomingStreamsMap[T incomingStream]` type, replacing separate bidi/uni-stream handling with one reusable structure.
- Splits `Session` into two maps: `incomingStreams` (`*incomingStreamsMap[*Stream]`) and `incomingUniStreams` (`*incomingStreamsMap[*ReceiveStream]`), each managing their own context and accept queue.
- Fixes a bug where `closeWithError` did not close incoming unidirectional streams; `incomingUniStreams.CloseSession` is now called alongside `incomingStreams.CloseSession`.
- Stream closure on session close now calls `closeWithSession(err)` on wrapped stream objects instead of canceling raw QUIC streams directly.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cea792c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->