### PR TITLE
add support for key exporters

### DIFF
--- a/session.go
+++ b/session.go
@@ -2,6 +2,7 @@ package webtransport
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
@@ -305,6 +306,29 @@ func (s *Session) SendDatagram(b []byte) error {
 
 func (s *Session) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return s.str.ReceiveDatagram(ctx)
+}
+
+// ExportKeyingMaterial exports keying material bound to this WebTransport session.
+func (s *Session) ExportKeyingMaterial(label string, context []byte, length int) ([]byte, error) {
+	if len(label) > 255 {
+		return nil, errors.New("webtransport: exporter label longer than 255 bytes")
+	}
+	if len(context) > 255 {
+		return nil, errors.New("webtransport: exporter context longer than 255 bytes")
+	}
+	if length < 0 {
+		return nil, errors.New("webtransport: exporter length must be non-negative")
+	}
+
+	exporterContext := make([]byte, 8, 8+1+len(label)+1+len(context))
+	binary.BigEndian.PutUint64(exporterContext, uint64(s.sessionID))
+	exporterContext = append(exporterContext, byte(len(label)))
+	exporterContext = append(exporterContext, label...)
+	exporterContext = append(exporterContext, byte(len(context)))
+	exporterContext = append(exporterContext, context...)
+
+	connState := s.conn.ConnectionState()
+	return connState.TLS.ExportKeyingMaterial("EXPORTER-WebTransport", exporterContext, length)
 }
 
 func (s *Session) closeWithError(closeErr error, closeCapsule *closeSessionCapsule) bool {

--- a/session_test.go
+++ b/session_test.go
@@ -181,6 +181,43 @@ func TestCloseWithErrorTruncatesSendMessage(t *testing.T) {
 	}
 }
 
+func TestExportKeyingMaterial(t *testing.T) {
+	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+	id := sessionID(0x1020304050607080)
+	clientSess := newSession(context.Background(), id, clientConn, mockHTTP3Stream{bytes.NewReader(nil)}, "")
+	serverSess := newSession(context.Background(), id, serverConn, mockHTTP3Stream{bytes.NewReader(nil)}, "")
+
+	label := "label"
+	context := []byte("context")
+	clientMaterial, err := clientSess.ExportKeyingMaterial(label, context, 32)
+	require.NoError(t, err)
+	serverMaterial, err := serverSess.ExportKeyingMaterial(label, context, 32)
+	require.NoError(t, err)
+	require.Equal(t, clientMaterial, serverMaterial)
+
+	exporterContext := make([]byte, 8, 8+1+len(label)+1+len(context))
+	binary.BigEndian.PutUint64(exporterContext, uint64(id))
+	exporterContext = append(exporterContext, byte(len(label)))
+	exporterContext = append(exporterContext, label...)
+	exporterContext = append(exporterContext, byte(len(context)))
+	exporterContext = append(exporterContext, context...)
+	connState := clientConn.ConnectionState()
+	expected, err := connState.TLS.ExportKeyingMaterial("EXPORTER-WebTransport", exporterContext, 32)
+	require.NoError(t, err)
+	require.Equal(t, expected, clientMaterial)
+
+	otherMaterial, err := clientSess.ExportKeyingMaterial("other", context, 32)
+	require.NoError(t, err)
+	require.NotEqual(t, clientMaterial, otherMaterial)
+
+	_, err = clientSess.ExportKeyingMaterial(strings.Repeat("a", 256), nil, 32)
+	require.ErrorContains(t, err, "exporter label")
+	_, err = clientSess.ExportKeyingMaterial(label, bytes.Repeat([]byte("a"), 256), 32)
+	require.ErrorContains(t, err, "exporter context")
+	_, err = clientSess.ExportKeyingMaterial(label, nil, -1)
+	require.ErrorContains(t, err, "non-negative")
+}
+
 func TestCapsuleParseErrorClosesSessionWithDatagramError(t *testing.T) {
 	b := quicvarint.Append(nil, uint64(maxStreamsBidiCapsuleType))
 	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))


### PR DESCRIPTION
Fixes #115.

Waiting for @mxinden to cut a new Neqo release that includes https://github.com/mozilla/neqo/pull/3464, so we can test with Firefox Nightly.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Session.ExportKeyingMaterial` for TLS keying material export
> - Adds `ExportKeyingMaterial` on `Session` in [session.go](https://github.com/quic-go/webtransport-go/pull/310/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac), which derives keying material via the TLS exporter using the label `"EXPORTER-WebTransport"` and a constructed context containing the session ID, label, and context bytes.
> - Input validation enforces label and context lengths <= 255 bytes and a non-negative output length.
> - The exporter context is scoped per-session by prepending the 8-byte big-endian session ID, ensuring different sessions produce different keying material for the same label and context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a264bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->