### PR TITLE
send WT_MAX_STREAMS capsules to grant new stream credit

### DIFF
--- a/session.go
+++ b/session.go
@@ -76,9 +76,13 @@ func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str h
 		applicationProtocol: applicationProtocol,
 		ctx:                 ctx,
 		capsuleQueueUpdated: make(chan struct{}, 1),
-		incomingStreams:     newIncomingStreamsMap[*Stream](),
-		incomingUniStreams:  newIncomingStreamsMap[*ReceiveStream](),
 	}
+	c.incomingStreams = newIncomingStreamsMap[*Stream](maxStreamsLimit, func(limit uint64) {
+		c.queueCapsule(maxStreamsBidiCapsule{MaximumStreams: limit})
+	})
+	c.incomingUniStreams = newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, func(limit uint64) {
+		c.queueCapsule(maxStreamsUniCapsule{MaximumStreams: limit})
+	})
 	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, c.queueCapsule)
 	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, c.queueCapsule)
 
@@ -206,13 +210,13 @@ func (s *Session) queueCapsule(c capsule) {
 // addIncomingStream adds a bidirectional stream that the remote peer opened
 func (s *Session) addIncomingStream(qstr *quic.Stream) {
 	id := qstr.StreamID()
-	s.incomingStreams.addStream(id, newStream(qstr, nil, func() { s.incomingStreams.removeStream(id) }))
+	s.incomingStreams.AddStream(id, newStream(qstr, nil, func() { s.incomingStreams.RemoveStream(id) }))
 }
 
 // addIncomingUniStream adds a unidirectional stream that the remote peer opened
 func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
 	id := qstr.StreamID()
-	s.incomingUniStreams.addStream(id, newReceiveStream(qstr, func() { s.incomingUniStreams.removeStream(id) }))
+	s.incomingUniStreams.AddStream(id, newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) }))
 }
 
 // Context returns a context that is closed when the session is closed.

--- a/stream_test.go
+++ b/stream_test.go
@@ -206,9 +206,9 @@ func TestReceiveStreamSessionGone(t *testing.T) {
 func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newIncomingStreamsMap[*ReceiveStream]()
-	str := newReceiveStream(recvStr, func() { sm.removeStream(recvStr.StreamID()) })
-	sm.addStream(recvStr.StreamID(), str)
+	sm := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, nil)
+	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) })
+	sm.AddStream(recvStr.StreamID(), str)
 
 	// start reading
 	errChan := make(chan error, 1)

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -59,6 +59,9 @@ type incomingStreamsMap[T incomingStream] struct {
 	acceptQueue     acceptQueue[T]
 	queueMaxStreams func(uint64)
 
+	maxStreamsMx     sync.Mutex
+	queuedMaxStreams uint64
+
 	mx sync.Mutex
 	m  map[quic.StreamID]T
 
@@ -74,13 +77,14 @@ func newIncomingStreamsMap[T incomingStream](maxOpenStreams uint64, queueMaxStre
 	}
 	ctx, cancel := context.WithCancelCause(context.Background())
 	return &incomingStreamsMap[T]{
-		ctx:             ctx,
-		cancel:          cancel,
-		acceptQueue:     *newAcceptQueue[T](),
-		queueMaxStreams: queueMaxStreams,
-		maxStreams:      maxOpenStreams,
-		maxOpenStreams:  maxOpenStreams,
-		m:               make(map[quic.StreamID]T),
+		ctx:              ctx,
+		cancel:           cancel,
+		acceptQueue:      *newAcceptQueue[T](),
+		queueMaxStreams:  queueMaxStreams,
+		queuedMaxStreams: maxOpenStreams,
+		maxStreams:       maxOpenStreams,
+		maxOpenStreams:   maxOpenStreams,
+		m:                make(map[quic.StreamID]T),
 	}
 }
 
@@ -116,9 +120,14 @@ func (s *incomingStreamsMap[T]) RemoveStream(id quic.StreamID) {
 		}
 	}
 	s.mx.Unlock()
-
 	if shouldQueue {
-		s.queueMaxStreams(maxStreams)
+		s.maxStreamsMx.Lock()
+		if maxStreams > s.queuedMaxStreams {
+			s.queuedMaxStreams = maxStreams
+			// WT_MAX_STREAMS must not be queued out of order
+			s.queueMaxStreams(maxStreams)
+		}
+		s.maxStreamsMx.Unlock()
 	}
 }
 

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -56,39 +56,70 @@ type incomingStreamsMap[T incomingStream] struct {
 	ctx    context.Context
 	cancel context.CancelCauseFunc
 
-	acceptQueue acceptQueue[T]
+	acceptQueue     acceptQueue[T]
+	queueMaxStreams func(uint64)
 
 	mx sync.Mutex
 	m  map[quic.StreamID]T
+
+	numStreams     uint64 // total number of streams opened by the peer
+	maxStreams     uint64 // stream limit, as advertised to the peer
+	maxOpenStreams uint64 // maximum number of concurrently open streams
 }
 
-func newIncomingStreamsMap[T incomingStream]() *incomingStreamsMap[T] {
+func newIncomingStreamsMap[T incomingStream](maxOpenStreams uint64, queueMaxStreams func(uint64)) *incomingStreamsMap[T] {
+	maxOpenStreams = min(maxOpenStreams, maxStreamsLimit)
+	if queueMaxStreams == nil {
+		queueMaxStreams = func(uint64) {}
+	}
 	ctx, cancel := context.WithCancelCause(context.Background())
 	return &incomingStreamsMap[T]{
-		ctx:         ctx,
-		cancel:      cancel,
-		acceptQueue: *newAcceptQueue[T](),
-		m:           make(map[quic.StreamID]T),
+		ctx:             ctx,
+		cancel:          cancel,
+		acceptQueue:     *newAcceptQueue[T](),
+		queueMaxStreams: queueMaxStreams,
+		maxStreams:      maxOpenStreams,
+		maxOpenStreams:  maxOpenStreams,
+		m:               make(map[quic.StreamID]T),
 	}
 }
 
-func (s *incomingStreamsMap[T]) addStream(id quic.StreamID, str T) {
+func (s *incomingStreamsMap[T]) AddStream(id quic.StreamID, str T) {
 	s.mx.Lock()
 	if closeErr := context.Cause(s.ctx); closeErr != nil {
 		s.mx.Unlock()
 		str.closeWithSession(closeErr)
 		return
 	}
+	s.numStreams++
 	s.m[id] = str
 	s.mx.Unlock()
 
 	s.acceptQueue.add(str)
 }
 
-func (s *incomingStreamsMap[T]) removeStream(id quic.StreamID) {
+func (s *incomingStreamsMap[T]) RemoveStream(id quic.StreamID) {
 	s.mx.Lock()
+	if _, ok := s.m[id]; !ok {
+		s.mx.Unlock()
+		return
+	}
 	delete(s.m, id)
+
+	var maxStreams uint64
+	var shouldQueue bool
+	if uint64(len(s.m)) < s.maxOpenStreams && s.maxStreams < maxStreamsLimit {
+		maxStreams = min(s.numStreams+s.maxOpenStreams-uint64(len(s.m)), maxStreamsLimit)
+		if maxStreams > s.maxStreams {
+			s.maxStreams = maxStreams
+			shouldQueue = true
+		}
+	}
 	s.mx.Unlock()
+
+	if shouldQueue {
+		s.queueMaxStreams(maxStreams)
+	}
 }
 
 func (s *incomingStreamsMap[T]) AcceptStream(ctx context.Context) (T, error) {

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -12,8 +12,8 @@ import (
 func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	ctx := context.Background()
 	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
-	streams := newIncomingStreamsMap[*Stream]()
-	uniStreams := newIncomingStreamsMap[*ReceiveStream]()
+	streams := newIncomingStreamsMap[*Stream](maxStreamsLimit, nil)
+	uniStreams := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, nil)
 
 	serverStr, err := serverConn.OpenStream()
 	require.NoError(t, err)
@@ -22,7 +22,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID := clientStr.StreamID()
-	streams.addStream(streamID, newStream(clientStr, nil, func() { streams.removeStream(streamID) }))
+	streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) }))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID = clientStr.StreamID()
-	streams.addStream(streamID, newStream(clientStr, nil, func() { streams.removeStream(streamID) }))
+	streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) }))
 
 	select {
 	case <-serverStr.Context().Done():
@@ -60,7 +60,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientUniStr, err := clientConn.AcceptUniStream(ctx)
 	require.NoError(t, err)
 	uniStreamID := clientUniStr.StreamID()
-	uniStreams.addStream(uniStreamID, newReceiveStream(clientUniStr, func() { uniStreams.removeStream(uniStreamID) }))
+	uniStreams.AddStream(uniStreamID, newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }))
 
 	select {
 	case <-serverUniStr.Context().Done():
@@ -74,12 +74,12 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 }
 
 func TestIncomingStreamsMapCloseSessionUnblocksAcceptStream(t *testing.T) {
-	streams := newIncomingStreamsMap[*Stream]()
+	streams := newIncomingStreamsMap[*Stream](maxStreamsLimit, nil)
 	sessionErr := &SessionError{ErrorCode: 42, Message: "bye"}
 
 	errChan := make(chan error, 1)
 	go func() {
-		_, err := streams.AcceptStream(context.Background())
+		_, err := streams.AcceptStream(t.Context())
 		errChan <- err
 	}()
 
@@ -90,4 +90,36 @@ func TestIncomingStreamsMapCloseSessionUnblocksAcceptStream(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	}
+}
+
+func TestIncomingStreamsMapQueuesMaxStreamsOnRemove(t *testing.T) {
+	var capsules []uint64
+	streams := newIncomingStreamsMap[*ReceiveStream](3, func(limit uint64) {
+		capsules = append(capsules, limit)
+	})
+
+	streams.AddStream(1, newReceiveStream(nil, nil))
+	streams.AddStream(2, newReceiveStream(nil, nil))
+
+	streams.RemoveStream(1)
+	require.Equal(t, []uint64{4}, capsules)
+
+	streams.RemoveStream(2)
+	require.Equal(t, []uint64{4, 5}, capsules)
+}
+
+func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
+	var capsules []uint64
+	streams := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit-1, func(limit uint64) {
+		capsules = append(capsules, limit)
+	})
+
+	streams.AddStream(1, newReceiveStream(nil, nil))
+	streams.AddStream(2, newReceiveStream(nil, nil))
+
+	streams.RemoveStream(1)
+	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
+
+	streams.RemoveStream(2)
+	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Send WT_MAX_STREAMS capsules to grant new stream credit when incoming streams close
- Extends `incomingStreamsMap` in [`streams_map_incoming.go`](https://github.com/quic-go/webtransport-go/pull/311/files#diff-abe44939d50a8c49cf8b8c0873c58ec6f888fdd5e51e15c45e9109c5ea809f27) to track open stream counts and advertised limits, queuing `WT_MAX_STREAMS` capsules when removing a stream would allow the limit to increase.
- `newIncomingStreamsMap` now accepts a `maxOpenStreams` cap and an optional `queueMaxStreams` callback; `addStream`/`removeStream` are renamed to exported `AddStream`/`RemoveStream`.
- `newSession` in [`session.go`](https://github.com/quic-go/webtransport-go/pull/311/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) wires up the callback so bidi and uni stream maps queue `WT_MAX_STREAMS_BIDI` and `WT_MAX_STREAMS_UNI` capsules respectively via `queueCapsule`.
- New tests cover capsule queuing on stream removal and enforcement of the `maxStreamsLimit` cap.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 481047b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->