### PR TITLE
reject WT_MAX_STREAMS that decrease the stream limit

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -41,6 +41,9 @@ const (
 	// WTSessionGoneErrorCode is the error code of the WT_SESSION_GONE error.
 	WTSessionGoneErrorCode quic.StreamErrorCode = 0x170d7b68
 
+	// WTFlowControlErrorCode is the error code of the WT_FLOW_CONTROL_ERROR error.
+	WTFlowControlErrorCode quic.StreamErrorCode = 0x045d4487
+
 	// WTRequirementsNotMetErrorCode is the error code of the
 	// WT_REQUIREMENTS_NOT_MET error.
 	WTRequirementsNotMetErrorCode quic.ApplicationErrorCode = 0x212c0d48

--- a/session.go
+++ b/session.go
@@ -104,8 +104,22 @@ func (s *Session) readFromConnectStream() {
 		case closeSessionCapsule:
 			s.closeWithError(c.ToSessionError(), nil)
 			return
-		case maxStreamsBidiCapsule, maxStreamsUniCapsule:
-			// TODO: handle max streams capsules
+		case maxStreamsBidiCapsule:
+			if err := s.outgoingStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
+				s.closeWithError(&http3.Error{
+					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
+					ErrorMessage: err.Error(),
+				}, nil)
+				return
+			}
+		case maxStreamsUniCapsule:
+			if err := s.outgoingUniStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
+				s.closeWithError(&http3.Error{
+					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
+					ErrorMessage: err.Error(),
+				}, nil)
+				return
+			}
 		case streamsBlockedBidiCapsule, streamsBlockedUniCapsule:
 			// TODO: log blocked capsules
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -240,6 +240,25 @@ func TestForbiddenStreamDataFlowControlCapsulesCloseSession(t *testing.T) {
 	}
 }
 
+func TestMaxStreamsCapsuleDecreaseClosesSession(t *testing.T) {
+	b := (maxStreamsBidiCapsule{MaximumStreams: maxOutgoingStreams}).Append(nil)
+	b = (maxStreamsBidiCapsule{MaximumStreams: maxOutgoingStreams - 1}).Append(b)
+
+	sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+	select {
+	case <-sess.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	sess.closeMx.Lock()
+	err := sess.closeErr
+	sess.closeMx.Unlock()
+
+	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
+	require.ErrorContains(t, err, errMaxStreamsDecreased.Error())
+}
+
 func TestSessionSendsQueuedCapsules(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -2,6 +2,8 @@ package webtransport
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand/v2"
 	"slices"
 	"sync"
@@ -15,6 +17,8 @@ import (
 type StreamLimitReachedError struct{}
 
 func (e StreamLimitReachedError) Error() string { return "too many open streams" }
+
+var errMaxStreamsDecreased = errors.New("webtransport: WT_MAX_STREAMS capsule decreased stream limit")
 
 const (
 	maxOutgoingStreams = 1 << 60
@@ -276,16 +280,20 @@ func (s *outgoingStreamsMap[T]) waitForStreamLimit(ctx context.Context) error {
 	return nil
 }
 
-func (s *outgoingStreamsMap[T]) UpdateStreamLimit(limit uint64) {
+func (s *outgoingStreamsMap[T]) UpdateStreamLimit(limit uint64) error {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	if limit <= s.maxStreams || s.closeErr != nil {
-		return
+	if s.closeErr != nil || limit == s.maxStreams {
+		return nil
+	}
+	if limit < s.maxStreams {
+		return fmt.Errorf("%w: current limit: %d, received limit: %d", errMaxStreamsDecreased, s.maxStreams, limit)
 	}
 	s.maxStreams = limit
 	s.blockedSent = false
 	s.maybeUnblockOpenSync()
+	return nil
 }
 
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream.

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -183,7 +183,7 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 	}
 
 	// allow 2 more streams
-	streams.UpdateStreamLimit(5)
+	require.NoError(t, streams.UpdateStreamLimit(5))
 	for range 2 {
 		select {
 		case <-openStreamSyncCalled:
@@ -208,7 +208,7 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 	default:
 	}
 
-	streams.UpdateStreamLimit(6)
+	require.NoError(t, streams.UpdateStreamLimit(6))
 	select {
 	case <-openStreamSyncCalled:
 	case <-time.After(time.Second):
@@ -234,6 +234,23 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 			t.Fatal("timeout waiting for stream")
 		}
 	}
+}
+
+func TestOutgoingStreamsMapUpdateStreamLimitDuplicateAndDecrease(t *testing.T) {
+	streams := newOutgoingStreamsMap(
+		func() (*outgoingStreamForTests, quic.StreamID, error) { return &outgoingStreamForTests{}, 0, nil },
+		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
+			return &outgoingStreamForTests{}, 0, nil
+		},
+		func(uint64) {},
+	)
+	streams.maxStreams = 5
+
+	require.NoError(t, streams.UpdateStreamLimit(5))
+	err := streams.UpdateStreamLimit(4)
+	require.ErrorIs(t, err, errMaxStreamsDecreased)
+	require.ErrorContains(t, err, "current limit: 5, received limit: 4")
+	require.Equal(t, uint64(5), streams.maxStreams)
 }
 
 func TestOutgoingStreamsMapQueueBlockedCanCloseSession(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reject `WT_MAX_STREAMS` capsules that decrease the stream limit
- `outgoingStreamsMap.UpdateStreamLimit` in [streams_map_outgoing.go](https://github.com/quic-go/webtransport-go/pull/312/files#diff-c615463dd5462bd1b530fa8c6fa108413a258c0d8c7f268fd31d44c8d371ab33) now returns an error when the new limit is less than the current one, using the sentinel `errMaxStreamsDecreased`; duplicate limits are treated as no-ops.
- [session.go](https://github.com/quic-go/webtransport-go/pull/312/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) handles `MAX_STREAMS_BIDI` and `MAX_STREAMS_UNI` capsules by calling `UpdateStreamLimit` and closing the session with `WT_FLOW_CONTROL_ERROR` if a decrease is detected.
- Behavioral Change: previously, decreasing stream limits were silently ignored; they now terminate the session with an error.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 657e964.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->