### PR TITLE
reset the CONNECT stream with H3_MESSAGE_ERROR on data after WT_CLOSE_SESSION

### DIFF
--- a/session.go
+++ b/session.go
@@ -106,6 +106,19 @@ func (s *Session) readFromConnectStream() {
 		}
 		switch c := c.(type) {
 		case closeSessionCapsule:
+			// Per draft-ietf-webtrans-http3-15 §6, an endpoint that sends a
+			// WT_CLOSE_SESSION capsule MUST immediately send a FIN, so a
+			// conformant peer produces EOF here. Any additional stream data is a
+			// protocol violation and MUST be answered by resetting the CONNECT
+			// stream with H3_MESSAGE_ERROR.
+			var b [1]byte
+			if n, _ := s.str.Read(b[:]); n > 0 {
+				s.closeWithError(&http3.Error{
+					ErrorCode:    http3.ErrCodeMessageError,
+					ErrorMessage: "webtransport: received data after WT_CLOSE_SESSION capsule",
+				}, nil)
+				return
+			}
 			s.closeWithError(c.ToSessionError(), nil)
 			return
 		case maxStreamsBidiCapsule:

--- a/session_test.go
+++ b/session_test.go
@@ -32,6 +32,26 @@ func (s mockHTTP3Stream) CancelRead(quic.StreamErrorCode)                 {}
 func (s mockHTTP3Stream) CancelWrite(quic.StreamErrorCode)                {}
 func (s mockHTTP3Stream) SetWriteDeadline(time.Time) error                { return nil }
 
+// recordingHTTP3Stream is a mockHTTP3Stream that records the error codes passed
+// to CancelRead / CancelWrite, so tests can assert the stream reset code.
+type recordingHTTP3Stream struct {
+	*bytes.Reader
+	canceled  bool
+	readCode  quic.StreamErrorCode
+	writeCode quic.StreamErrorCode
+}
+
+func (s *recordingHTTP3Stream) Write(p []byte) (int, error)                     { return len(p), nil }
+func (s *recordingHTTP3Stream) Close() error                                    { return nil }
+func (s *recordingHTTP3Stream) ReceiveDatagram(context.Context) ([]byte, error) { return nil, io.EOF }
+func (s *recordingHTTP3Stream) SendDatagram([]byte) error                       { return nil }
+func (s *recordingHTTP3Stream) CancelRead(code quic.StreamErrorCode) {
+	s.canceled = true
+	s.readCode = code
+}
+func (s *recordingHTTP3Stream) CancelWrite(code quic.StreamErrorCode) { s.writeCode = code }
+func (s *recordingHTTP3Stream) SetWriteDeadline(time.Time) error      { return nil }
+
 type quicHTTP3Stream struct{ *quic.Stream }
 
 func (s quicHTTP3Stream) ReceiveDatagram(context.Context) ([]byte, error) { return nil, io.EOF }
@@ -273,6 +293,100 @@ func TestMaxStreamsCapsuleDecreaseClosesSession(t *testing.T) {
 
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
 	require.ErrorContains(t, err, errMaxStreamsDecreased.Error())
+}
+
+// TestTrailingDataAfterCloseSessionResetsWithMessageError verifies that stream
+// data received after a WT_CLOSE_SESSION capsule resets the CONNECT stream with
+// H3_MESSAGE_ERROR, per draft-ietf-webtrans-http3-15 §6.
+func TestTrailingDataAfterCloseSessionResetsWithMessageError(t *testing.T) {
+	b := (closeSessionCapsule{ErrorCode: 42, Message: "bye"}).Append(nil)
+	b = append(b, []byte("unexpected trailing data")...)
+
+	str := &recordingHTTP3Stream{Reader: bytes.NewReader(b)}
+	sess := newSession(context.Background(), 42, nil, str, "")
+	select {
+	case <-sess.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	sess.closeMx.Lock()
+	err := sess.closeErr
+	sess.closeMx.Unlock()
+
+	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeMessageError})
+	require.ErrorContains(t, err, "received data after WT_CLOSE_SESSION")
+	require.True(t, str.canceled)
+	require.Equal(t, quic.StreamErrorCode(http3.ErrCodeMessageError), str.readCode)
+	require.Equal(t, quic.StreamErrorCode(http3.ErrCodeMessageError), str.writeCode)
+}
+
+// TestCleanCloseSessionCancelsWithSessionGone locks in the behavior for a
+// conformant peer that sends a WT_CLOSE_SESSION capsule followed by a FIN: the
+// session surfaces the peer's SessionError and cancels with WT_SESSION_GONE.
+func TestCleanCloseSessionCancelsWithSessionGone(t *testing.T) {
+	b := (closeSessionCapsule{ErrorCode: 1234, Message: "graceful"}).Append(nil)
+
+	str := &recordingHTTP3Stream{Reader: bytes.NewReader(b)}
+	sess := newSession(context.Background(), 42, nil, str, "")
+	select {
+	case <-sess.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	sess.closeMx.Lock()
+	err := sess.closeErr
+	sess.closeMx.Unlock()
+
+	require.ErrorIs(t, err, &SessionError{Remote: true, ErrorCode: 1234})
+	require.True(t, str.canceled)
+	require.Equal(t, WTSessionGoneErrorCode, str.readCode)
+	require.Equal(t, WTSessionGoneErrorCode, str.writeCode)
+}
+
+// TestTrailingDataAfterCloseSessionResetsConnectStream is the end-to-end variant
+// over a real QUIC connection: the peer writes a WT_CLOSE_SESSION capsule plus
+// illegal trailing data (no FIN), and observes the CONNECT stream reset with
+// H3_MESSAGE_ERROR.
+func TestTrailingDataAfterCloseSessionResetsConnectStream(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	clientConn, serverConn := newConnPair(t, newUDPConnLocalhost(t), newUDPConnLocalhost(t))
+
+	// The peer opens the stream and writes the capsule + illegal trailing data
+	// (no FIN). Writing makes the stream visible to the client's AcceptStream.
+	serverStr, err := serverConn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	b := (closeSessionCapsule{ErrorCode: 7, Message: "done"}).Append(nil)
+	b = append(b, []byte("trailing")...)
+	_, err = serverStr.Write(b)
+	require.NoError(t, err)
+
+	clientStr, err := clientConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	sess := newSession(context.Background(), 0, clientConn, quicHTTP3Stream{clientStr}, "")
+
+	select {
+	case <-sess.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+	sess.closeMx.Lock()
+	closeErr := sess.closeErr
+	sess.closeMx.Unlock()
+	require.ErrorIs(t, closeErr, &http3.Error{ErrorCode: http3.ErrCodeMessageError})
+
+	require.NoError(t, serverStr.SetReadDeadline(time.Now().Add(time.Second)))
+	buf := make([]byte, 16)
+	for err == nil {
+		_, err = serverStr.Read(buf)
+	}
+	require.ErrorIs(t, err, &quic.StreamError{
+		StreamID:  serverStr.StreamID(),
+		ErrorCode: quic.StreamErrorCode(http3.ErrCodeMessageError),
+		Remote:    true,
+	})
 }
 
 func TestSessionSendsQueuedCapsules(t *testing.T) {


### PR DESCRIPTION
Implements draft-ietf-webtrans-http3-15 §6: an endpoint that sends a `WT_CLOSE_SESSION` capsule must immediately FIN the CONNECT stream, so any further stream data is a protocol violation that must be answered by resetting the stream with `H3_MESSAGE_ERROR`. Previously the close capsule simply ended the read loop and the stream was cancelled with `WT_SESSION_GONE`, silently dropping trailing data.

## Changes
- `session.go`: after parsing a `closeSessionCapsule`, probe the CONNECT stream. `EOF` (FIN) keeps the existing clean-close path (`WT_SESSION_GONE`); trailing data closes via `http3.Error{H3_MESSAGE_ERROR}`, which resets read and write with `0x10e`. A blocking probe fits the existing dedicated read-goroutine model, which already blocks in `parseNextCapsule`, so it adds no new interface surface or hang risk.
- `session_test.go`: add `recordingHTTP3Stream` (records cancel codes) and three tests — trailing data resets with `H3_MESSAGE_ERROR`, a clean FIN still cancels with `WT_SESSION_GONE`, and an end-to-end variant over a real QUIC connection where the peer observes the remote reset code.

## Validation
- The end-to-end test drives a real QUIC connection and asserts the peer observes the CONNECT stream reset with `H3_MESSAGE_ERROR`.
- Note for reviewers: `go test -race` surfaces a data race in the `TestApplicationProtocolNegotiation` helper; it is pre-existing on `master` and unrelated to this change (CI runs `go test` without `-race`).

Closes #313. Adjacent §6 message length / UTF-8 validation gap tracked in #316.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset CONNECT stream with H3_MESSAGE_ERROR on data received after WT_CLOSE_SESSION
> - In `Session.readFromConnectStream` ([session.go](https://github.com/quic-go/webtransport-go/pull/317/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac)), after parsing a `WT_CLOSE_SESSION` capsule, the method now reads ahead one byte to check for trailing stream data.
> - If trailing data is present, the CONNECT stream is reset with `H3_MESSAGE_ERROR`; if a clean FIN is received, the session closes normally with the peer's `SessionError`.
> - Unit tests cover both the trailing-data and clean-close paths; an end-to-end test over a real QUIC connection verifies the reset is observed by the server.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d64b26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of session-close messages so unexpected data after close now triggers a protocol error instead of being accepted.
  * Ensured clean session shutdowns continue to surface the correct remote session status.
  * Added coverage for trailing data, clean EOF handling, and end-to-end stream reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->