### PR TITLE
reject non-increasing WT_MAX_STREAMS limits

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -272,7 +272,7 @@ func TestMaxStreamsCapsuleDecreaseClosesSession(t *testing.T) {
 	sess.closeMx.Unlock()
 
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
-	require.ErrorContains(t, err, errMaxStreamsDecreased.Error())
+	require.ErrorContains(t, err, errMaxStreamsNotIncreased.Error())
 }
 
 func TestSessionSendsQueuedCapsules(t *testing.T) {

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -18,7 +18,7 @@ type StreamLimitReachedError struct{}
 
 func (e StreamLimitReachedError) Error() string { return "too many open streams" }
 
-var errMaxStreamsDecreased = errors.New("webtransport: WT_MAX_STREAMS capsule decreased stream limit")
+var errMaxStreamsNotIncreased = errors.New("webtransport: WT_MAX_STREAMS capsule didn't increase stream limit")
 
 const (
 	maxOutgoingStreams = 1 << 60
@@ -284,11 +284,11 @@ func (s *outgoingStreamsMap[T]) UpdateStreamLimit(limit uint64) error {
 	s.mx.Lock()
 	defer s.mx.Unlock()
 
-	if s.closeErr != nil || limit == s.maxStreams {
+	if s.closeErr != nil {
 		return nil
 	}
-	if limit < s.maxStreams {
-		return fmt.Errorf("%w: current limit: %d, received limit: %d", errMaxStreamsDecreased, s.maxStreams, limit)
+	if limit <= s.maxStreams {
+		return fmt.Errorf("%w: current limit: %d, received limit: %d", errMaxStreamsNotIncreased, s.maxStreams, limit)
 	}
 	s.maxStreams = limit
 	s.blockedSent = false

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -246,9 +246,11 @@ func TestOutgoingStreamsMapUpdateStreamLimitDuplicateAndDecrease(t *testing.T) {
 	)
 	streams.maxStreams = 5
 
-	require.NoError(t, streams.UpdateStreamLimit(5))
-	err := streams.UpdateStreamLimit(4)
-	require.ErrorIs(t, err, errMaxStreamsDecreased)
+	err := streams.UpdateStreamLimit(5)
+	require.ErrorIs(t, err, errMaxStreamsNotIncreased)
+	require.ErrorContains(t, err, "current limit: 5, received limit: 5")
+	err = streams.UpdateStreamLimit(4)
+	require.ErrorIs(t, err, errMaxStreamsNotIncreased)
 	require.ErrorContains(t, err, "current limit: 5, received limit: 4")
 	require.Equal(t, uint64(5), streams.maxStreams)
 }


### PR DESCRIPTION
This was recently changed in the draft: https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http3/pull/279

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject non-increasing `WT_MAX_STREAMS` limits in `outgoingStreamsMap.UpdateStreamLimit`
> Previously, `UpdateStreamLimit` only errored on strictly decreasing limits; equal limits returned nil. Now it returns an error when the new limit is less than or equal to the current `maxStreams`, wrapping the renamed sentinel `errMaxStreamsNotIncreased` with both the current and received values.
>
> - Renames `errMaxStreamsDecreased` to `errMaxStreamsNotIncreased` with an updated message in [streams_map_outgoing.go](https://github.com/quic-go/webtransport-go/pull/324/files#diff-c615463dd5462bd1b530fa8c6fa108413a258c0d8c7f268fd31d44c8d371ab33).
> - Risk: any `errors.Is` checks against the old `errMaxStreamsDecreased` sentinel will no longer match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0490138.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of advertised outgoing stream limits.
  * Repeated or reduced stream limits are now rejected consistently, preventing invalid flow-control updates.
  * Sessions receiving a non-increasing stream limit now report the correct error and close as expected.
  * Error details identify both the current and received limits for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->