### PR TITLE
add a Config to set incoming and outgoing stream limits

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,9 @@ import (
 )
 
 type Dialer struct {
+	// Config is the WebTransport configuration used for new sessions.
+	Config *Config
+
 	// TLSClientConfig is the TLS client config used when dialing the QUIC connection.
 	// It must set the h3 ALPN.
 	TLSClientConfig *tls.Config
@@ -53,6 +56,10 @@ func (d *Dialer) init() {
 
 func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
 	d.initOnce.Do(func() { d.init() })
+	var config Config
+	if d.Config != nil {
+		config = *d.Config
+	}
 
 	quicConf := d.QUICConfig
 	if quicConf == nil {
@@ -119,11 +126,10 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
 	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
 	// for its supported draft version, so the server can negotiate the version.
-	tr := &http3.Transport{
-		EnableDatagrams:    true,
-		AdditionalSettings: map[uint64]uint64{settingsWebTransportEnabled: 1},
-	}
-	rsp, sess, err := d.handleConn(ctx, tr, qconn, req)
+	additionalSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
+	config.addSettings(additionalSettings)
+	tr := &http3.Transport{EnableDatagrams: true, AdditionalSettings: additionalSettings}
+	rsp, sess, err := d.handleConn(ctx, tr, qconn, req, config)
 	if err != nil {
 		var msg string
 		code := quic.ApplicationErrorCode(http3.ErrCodeNoError)
@@ -143,7 +149,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	return rsp, sess, nil
 }
 
-func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request) (*http.Response, *Session, error) {
+func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request, config Config) (*http.Response, *Session, error) {
 	timeout := d.StreamReorderingTimeout
 	if timeout == 0 {
 		timeout = 5 * time.Second
@@ -276,7 +282,7 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 			return rsp, nil, sessErr
 		}
 	}
-	sess := newSession(context.WithoutCancel(ctx), sessID, qconn, requestStr, protocol)
+	sess := newSession(context.WithoutCancel(ctx), sessID, qconn, requestStr, protocol, config.sessionFlowControl(settings))
 	sessMgr.AddSession(sessID, sess)
 	return rsp, sess, nil
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,68 @@
+package webtransport
+
+import "github.com/quic-go/quic-go/http3"
+
+// Config contains configuration for a WebTransport client or server.
+type Config struct {
+	// MaxIncomingStreams is the maximum number of concurrent bidirectional streams
+	// that the peer is allowed to open in a WebTransport session.
+	// If zero, SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI is not sent.
+	// If negative, the setting is sent with a value of zero.
+	// Values larger than 2^60 are clipped to 2^60.
+	MaxIncomingStreams int64
+
+	// MaxIncomingUniStreams is the maximum number of concurrent unidirectional streams
+	// that the peer is allowed to open in a WebTransport session.
+	// If zero, SETTINGS_WT_INITIAL_MAX_STREAMS_UNI is not sent.
+	// If negative, the setting is sent with a value of zero.
+	// Values larger than 2^60 are clipped to 2^60.
+	MaxIncomingUniStreams int64
+}
+
+type sessionFlowControl struct {
+	Enabled bool
+
+	MaxIncomingStreams    uint64
+	MaxIncomingUniStreams uint64
+	MaxOutgoingStreams    uint64
+	MaxOutgoingUniStreams uint64
+}
+
+func streamLimit(limit int64) uint64 {
+	if limit <= 0 {
+		return 0
+	}
+	return min(uint64(limit), uint64(maxStreamsLimit))
+}
+
+func (c Config) addSettings(settings map[uint64]uint64) {
+	delete(settings, settingsWebTransportInitialMaxStreamsBidi)
+	delete(settings, settingsWebTransportInitialMaxStreamsUni)
+	if c.MaxIncomingStreams != 0 {
+		settings[settingsWebTransportInitialMaxStreamsBidi] = streamLimit(c.MaxIncomingStreams)
+	}
+	if c.MaxIncomingUniStreams != 0 {
+		settings[settingsWebTransportInitialMaxStreamsUni] = streamLimit(c.MaxIncomingUniStreams)
+	}
+}
+
+func (c Config) sessionFlowControl(remote *http3.Settings) sessionFlowControl {
+	localEnabled := c.MaxIncomingStreams > 0 || c.MaxIncomingUniStreams > 0
+	if !localEnabled || remote == nil {
+		return sessionFlowControl{}
+	}
+	peerSettings := remote.Other
+	peerEnabled := peerSettings[settingsWebTransportInitialMaxStreamsBidi] > 0 ||
+		peerSettings[settingsWebTransportInitialMaxStreamsUni] > 0 ||
+		peerSettings[settingsWebTransportInitialMaxData] > 0
+	if !peerEnabled {
+		return sessionFlowControl{}
+	}
+	return sessionFlowControl{
+		Enabled:               true,
+		MaxIncomingStreams:    streamLimit(c.MaxIncomingStreams),
+		MaxIncomingUniStreams: streamLimit(c.MaxIncomingUniStreams),
+		MaxOutgoingStreams:    peerSettings[settingsWebTransportInitialMaxStreamsBidi],
+		MaxOutgoingUniStreams: peerSettings[settingsWebTransportInitialMaxStreamsUni],
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,104 @@
+package webtransport
+
+import (
+	"testing"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAddsStreamLimitSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config Config
+		want   map[uint64]uint64
+	}{
+		{
+			name: "zero values",
+			want: map[uint64]uint64{},
+		},
+		{
+			name:   "explicit zero",
+			config: Config{MaxIncomingStreams: -1, MaxIncomingUniStreams: -1},
+			want: map[uint64]uint64{
+				settingsWebTransportInitialMaxStreamsBidi: 0,
+				settingsWebTransportInitialMaxStreamsUni:  0,
+			},
+		},
+		{
+			name:   "positive",
+			config: Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: 20},
+			want: map[uint64]uint64{
+				settingsWebTransportInitialMaxStreamsBidi: 10,
+				settingsWebTransportInitialMaxStreamsUni:  20,
+			},
+		},
+		{
+			name:   "clipped",
+			config: Config{MaxIncomingStreams: 1<<60 + 1, MaxIncomingUniStreams: 1<<60 + 2},
+			want: map[uint64]uint64{
+				settingsWebTransportInitialMaxStreamsBidi: maxStreamsLimit,
+				settingsWebTransportInitialMaxStreamsUni:  maxStreamsLimit,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := map[uint64]uint64{
+				settingsWebTransportInitialMaxStreamsBidi: 42,
+				settingsWebTransportInitialMaxStreamsUni:  42,
+			}
+			tc.config.addSettings(settings)
+			require.Equal(t, tc.want, settings)
+		})
+	}
+}
+
+func TestConfigNegotiatesStreamFlowControl(t *testing.T) {
+	config := Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: -1}
+	remote := &http3.Settings{Other: map[uint64]uint64{
+		settingsWebTransportInitialMaxStreamsBidi: 3,
+		settingsWebTransportInitialMaxStreamsUni:  4,
+	}}
+	require.Equal(t, sessionFlowControl{
+		Enabled:               true,
+		MaxIncomingStreams:    10,
+		MaxIncomingUniStreams: 0,
+		MaxOutgoingStreams:    3,
+		MaxOutgoingUniStreams: 4,
+	}, config.sessionFlowControl(remote))
+
+	for _, tc := range []struct {
+		name    string
+		config  Config
+		remote  *http3.Settings
+		enabled bool
+	}{
+		{
+			name:   "disabled when local streams disabled",
+			config: Config{MaxIncomingStreams: -1},
+			remote: &http3.Settings{Other: map[uint64]uint64{
+				settingsWebTransportInitialMaxStreamsBidi: 3,
+			}},
+			enabled: false,
+		},
+		{
+			name:    "disabled when peer sends no flow control",
+			config:  config,
+			remote:  &http3.Settings{},
+			enabled: false,
+		},
+		{
+			name:   "enabled via max data",
+			config: config,
+			remote: &http3.Settings{Other: map[uint64]uint64{
+				settingsWebTransportInitialMaxData: 1,
+			}},
+			enabled: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.enabled, tc.config.sessionFlowControl(tc.remote).Enabled)
+		})
+	}
+}

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -1,0 +1,170 @@
+package webtransport_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/webtransport-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamFlowControl(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		clientOpens    bool
+		unidirectional bool
+	}{
+		{name: "client/bidirectional", clientOpens: true},
+		{name: "client/unidirectional", clientOpens: true, unidirectional: true},
+		{name: "server/bidirectional"},
+		{name: "server/unidirectional", unidirectional: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testStreamFlowControl(t, tc.clientOpens, tc.unidirectional)
+		})
+	}
+}
+
+func testStreamFlowControl(t *testing.T, clientOpens, unidirectional bool) {
+	const streamLimit = 2
+
+	config := &webtransport.Config{}
+	if unidirectional {
+		config.MaxIncomingUniStreams = streamLimit
+	} else {
+		config.MaxIncomingStreams = streamLimit
+	}
+
+	serverSessionChan := make(chan *webtransport.Session, 1)
+	server := &webtransport.Server{
+		H3:     &http3.Server{TLSConfig: webtransport.TLSConf},
+		Config: config,
+	}
+	addHandler(t, server, func(sess *webtransport.Session) { serverSessionChan <- sess })
+	addr, closeServer := runServer(t, server)
+
+	dialer := &webtransport.Dialer{
+		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		Config:          config,
+	}
+	defer func() {
+		require.NoError(t, dialer.Close())
+		closeServer()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(5*time.Second))
+	defer cancel()
+	rsp, clientSession, err := dialer.Dial(ctx, fmt.Sprintf("https://localhost:%d/webtransport", addr.Port), nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+
+	var serverSession *webtransport.Session
+	select {
+	case serverSession = <-serverSessionChan:
+	case <-ctx.Done():
+		t.Fatal("server didn't establish the WebTransport session")
+	}
+
+	opener, receiver := serverSession, clientSession
+	if clientOpens {
+		opener, receiver = clientSession, serverSession
+	}
+	if unidirectional {
+		testUnidirectionalStreamFlowControl(t, ctx, opener, receiver, streamLimit)
+	} else {
+		testBidirectionalStreamFlowControl(t, ctx, opener, receiver, streamLimit)
+	}
+}
+
+func testBidirectionalStreamFlowControl(t *testing.T, ctx context.Context, opener, receiver *webtransport.Session, streamLimit int) {
+	streams := make([]*webtransport.Stream, streamLimit)
+	var err error
+	for i := range streams {
+		streams[i], err = opener.OpenStream()
+		require.NoError(t, err)
+	}
+	_, err = opener.OpenStream()
+	var limitErr *webtransport.StreamLimitReachedError
+	require.ErrorAs(t, err, &limitErr)
+
+	openResult := make(chan error, 1)
+	go func() {
+		_, err := opener.OpenStreamSync(ctx)
+		openResult <- err
+	}()
+	requireStreamOpeningBlocked(t, openResult, "opening a stream unexpectedly completed")
+
+	const payload = "flow control"
+	_, err = io.WriteString(streams[0], payload)
+	require.NoError(t, err)
+	require.NoError(t, streams[0].Close())
+	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before the peer consumed it")
+
+	str, err := receiver.AcceptStream(ctx)
+	require.NoError(t, err)
+	// reading the EOF releases and closing the stream releases the stream credit
+	data, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(data))
+	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before both sides were closed")
+	require.NoError(t, str.Close())
+
+	select {
+	case err := <-openResult:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("opening a stream didn't unblock after the peer closed the previous stream")
+	}
+}
+
+func testUnidirectionalStreamFlowControl(t *testing.T, ctx context.Context, opener, receiver *webtransport.Session, streamLimit int) {
+	streams := make([]*webtransport.SendStream, streamLimit)
+	var err error
+	for i := range streams {
+		streams[i], err = opener.OpenUniStream()
+		require.NoError(t, err)
+	}
+	_, err = opener.OpenUniStream()
+	var limitErr *webtransport.StreamLimitReachedError
+	require.ErrorAs(t, err, &limitErr)
+
+	openResult := make(chan error, 1)
+	go func() {
+		_, err := opener.OpenUniStreamSync(ctx)
+		openResult <- err
+	}()
+	requireStreamOpeningBlocked(t, openResult, "opening a stream unexpectedly completed")
+
+	_, err = io.WriteString(streams[0], "lorem ipsum dolor sit amet")
+	require.NoError(t, err)
+	require.NoError(t, streams[0].Close())
+	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before the peer consumed it")
+
+	str, err := receiver.AcceptUniStream(ctx)
+	require.NoError(t, err)
+	// reading the EOF releases the stream credit
+	data, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, "lorem ipsum dolor sit amet", string(data))
+
+	select {
+	case err := <-openResult:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("opening a stream didn't unblock after the peer closed the previous stream")
+	}
+}
+
+func requireStreamOpeningBlocked(t *testing.T, result <-chan error, message string) {
+	t.Helper()
+	select {
+	case err := <-result:
+		t.Fatalf("%s: %v", message, err)
+	case <-time.After(scaleDuration(20 * time.Millisecond)):
+	}
+}

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ var quicConnKey = quicConnKeyType{}
 
 func ConfigureHTTP3Server(s *http3.Server) {
 	if s.AdditionalSettings == nil {
-		s.AdditionalSettings = make(map[uint64]uint64, 6)
+		s.AdditionalSettings = make(map[uint64]uint64, 3)
 	}
 	// send the old setting for backwards compatibility with older clients
 	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
@@ -45,11 +45,6 @@ func ConfigureHTTP3Server(s *http3.Server) {
 
 	// Safari requires SETTINGS_WT_MAX_SESSIONS >= 1 (draft-ietf-webtrans-http3-14)
 	s.AdditionalSettings[settingsWebTransportMaxSessions] = 1<<62 - 1
-
-	// Required when SETTINGS_WT_MAX_SESSIONS > 1
-	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsUni] = 1 << 60
-	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsBidi] = 1 << 60
-	s.AdditionalSettings[settingsWebTransportInitialMaxData] = 1 << 60
 
 	s.EnableDatagrams = true
 	origConnContext := s.ConnContext
@@ -64,6 +59,10 @@ func ConfigureHTTP3Server(s *http3.Server) {
 
 type Server struct {
 	H3 *http3.Server
+
+	// Config is the WebTransport configuration used for new sessions.
+	// If nil, the zero value is used.
+	Config *Config
 
 	// ApplicationProtocols is a list of application protocols that can be negotiated,
 	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15 for details.
@@ -89,6 +88,7 @@ type Server struct {
 
 	initOnce sync.Once
 	initErr  error
+	config   Config
 
 	connsMx sync.Mutex
 	conns   map[*quic.Conn]*sessionManager
@@ -111,6 +111,14 @@ func (s *Server) timeout() time.Duration {
 }
 
 func (s *Server) init() error {
+	if s.Config != nil {
+		s.config = *s.Config
+	}
+	if s.H3 != nil {
+		ConfigureHTTP3Server(s.H3)
+		s.config.addSettings(s.H3.AdditionalSettings)
+	}
+
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 
 	s.conns = make(map[*quic.Conn]*sessionManager)
@@ -430,7 +438,14 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 		return nil, errors.New("webtransport: connection session manager not found")
 	}
 
-	sess := newSession(context.WithoutCancel(r.Context()), sessID, conn, str, selectedProtocol)
+	sess := newSession(
+		context.WithoutCancel(r.Context()),
+		sessID,
+		conn,
+		str,
+		selectedProtocol,
+		s.config.sessionFlowControl(settings),
+	)
 	sessMgr.AddSession(sessID, sess)
 	return sess, nil
 }

--- a/session.go
+++ b/session.go
@@ -43,6 +43,7 @@ type Session struct {
 	conn                *quic.Conn
 	str                 http3Stream
 	applicationProtocol string
+	flowControlEnabled  bool
 
 	ctx      context.Context
 	closeMx  sync.Mutex
@@ -67,24 +68,38 @@ const (
 	closeSessionTimeout       = 10 * time.Millisecond
 )
 
-func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str http3Stream, applicationProtocol string) *Session {
+func newSession(
+	ctx context.Context,
+	sessionID sessionID,
+	conn *quic.Conn,
+	str http3Stream,
+	applicationProtocol string,
+	fc sessionFlowControl,
+) *Session {
 	ctx, ctxCancel := context.WithCancel(ctx)
 	c := &Session{
 		sessionID:           sessionID,
 		conn:                conn,
 		str:                 str,
 		applicationProtocol: applicationProtocol,
+		flowControlEnabled:  fc.Enabled,
 		ctx:                 ctx,
 		capsuleQueueUpdated: make(chan struct{}, 1),
 	}
-	c.incomingStreams = newIncomingStreamsMap[*Stream](maxStreamsLimit, func(limit uint64) {
+	if !fc.Enabled {
+		fc.MaxIncomingStreams = maxStreamsLimit
+		fc.MaxIncomingUniStreams = maxStreamsLimit
+		fc.MaxOutgoingStreams = maxStreamsLimit
+		fc.MaxOutgoingUniStreams = maxStreamsLimit
+	}
+	c.incomingStreams = newIncomingStreamsMap[*Stream](fc.MaxIncomingStreams, func(limit uint64) {
 		c.queueCapsule(maxStreamsBidiCapsule{MaximumStreams: limit})
 	})
-	c.incomingUniStreams = newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, func(limit uint64) {
+	c.incomingUniStreams = newIncomingStreamsMap[*ReceiveStream](fc.MaxIncomingUniStreams, func(limit uint64) {
 		c.queueCapsule(maxStreamsUniCapsule{MaximumStreams: limit})
 	})
-	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, c.queueCapsule)
-	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, c.queueCapsule)
+	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, fc.MaxOutgoingStreams, c.queueCapsule)
+	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, fc.MaxOutgoingUniStreams, c.queueCapsule)
 
 	go func() {
 		defer ctxCancel()
@@ -109,6 +124,9 @@ func (s *Session) readFromConnectStream() {
 			s.closeWithError(c.ToSessionError(), nil)
 			return
 		case maxStreamsBidiCapsule:
+			if !s.flowControlEnabled {
+				continue
+			}
 			if err := s.outgoingStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
 				s.closeWithError(&http3.Error{
 					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
@@ -117,6 +135,9 @@ func (s *Session) readFromConnectStream() {
 				return
 			}
 		case maxStreamsUniCapsule:
+			if !s.flowControlEnabled {
+				continue
+			}
 			if err := s.outgoingUniStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
 				s.closeWithError(&http3.Error{
 					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
@@ -125,6 +146,9 @@ func (s *Session) readFromConnectStream() {
 				return
 			}
 		case streamsBlockedBidiCapsule, streamsBlockedUniCapsule:
+			if !s.flowControlEnabled {
+				continue
+			}
 			// TODO: log blocked capsules
 		}
 	}
@@ -210,13 +234,21 @@ func (s *Session) queueCapsule(c capsule) {
 // addIncomingStream adds a bidirectional stream that the remote peer opened
 func (s *Session) addIncomingStream(qstr *quic.Stream) {
 	id := qstr.StreamID()
-	s.incomingStreams.AddStream(id, newStream(qstr, nil, func() { s.incomingStreams.RemoveStream(id) }))
+	str := newStream(qstr, nil, func() { s.incomingStreams.RemoveStream(id) })
+	if err := s.incomingStreams.AddStream(id, str); err != nil {
+		str.closeWithSession(err)
+		s.closeWithError(err, nil)
+	}
 }
 
 // addIncomingUniStream adds a unidirectional stream that the remote peer opened
 func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
 	id := qstr.StreamID()
-	s.incomingUniStreams.AddStream(id, newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) }))
+	str := newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) })
+	if err := s.incomingUniStreams.AddStream(id, str); err != nil {
+		str.closeWithSession(err)
+		s.closeWithError(err, nil)
+	}
 }
 
 // Context returns a context that is closed when the session is closed.

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -97,7 +97,7 @@ func TestSessionManagerAddingStreams(t *testing.T) {
 	sessMgr := newSessionManager(time.Hour)
 	require.Zero(t, sessMgr.NumSessions())
 	// first add the streams...
-	sess := newSession(context.Background(), sessionID, clientConn, reqStr, "")
+	sess := newSession(context.Background(), sessionID, clientConn, reqStr, "", sessionFlowControl{})
 	// ...then add the session
 	sessMgr.AddStream(clientStr, sessionID)
 	require.Equal(t, 1, sessMgr.NumSessions())
@@ -217,7 +217,7 @@ func TestSessionManagerStreamReordering(t *testing.T) {
 		require.Equal(t, 1, sessMgr.NumSessions())
 
 		// now add the session
-		sess := newSession(context.Background(), sessionID, clientConn, reqStr, "")
+		sess := newSession(context.Background(), sessionID, clientConn, reqStr, "", sessionFlowControl{})
 		sessMgr.AddSession(sessionID, sess)
 		require.Equal(t, 1, sessMgr.NumSessions())
 
@@ -305,7 +305,7 @@ func TestSessionManagerSessionClose(t *testing.T) {
 			require.NoError(t, err)
 			sessID := sessionID(rand.Int64N(quicvarint.Max))
 			reqStrs[sessID] = reqStr
-			sess := newSession(context.Background(), sessID, clientConn, reqStr, "")
+			sess := newSession(context.Background(), sessID, clientConn, reqStr, "", sessionFlowControl{})
 			sessMgr.AddSession(sessID, sess)
 			synctest.Wait()
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -183,7 +183,7 @@ func TestCloseWithErrorTruncatesSendMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
 
-	sess := newSession(context.Background(), 42, clientConn, reqStr, "")
+	sess := newSession(context.Background(), 42, clientConn, reqStr, "", sessionFlowControl{})
 	require.NoError(t, sess.CloseWithError(42, strings.Repeat("a", maxCloseCapsuleErrorMsgLen+500)))
 
 	select {
@@ -203,7 +203,14 @@ func TestCapsuleParseErrorClosesSessionWithDatagramError(t *testing.T) {
 	b = quicvarint.Append(b, 42)
 	b = append(b, 0)
 
-	sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+	sess := newSession(
+		context.Background(),
+		42,
+		nil,
+		mockHTTP3Stream{bytes.NewReader(b)},
+		"",
+		sessionFlowControl{Enabled: true},
+	)
 	select {
 	case <-sess.Context().Done():
 	case <-time.After(time.Second):
@@ -239,7 +246,14 @@ func TestForbiddenStreamDataFlowControlCapsulesCloseSession(t *testing.T) {
 			b := quicvarint.Append(nil, uint64(tc.typ))
 			b = quicvarint.Append(b, 0)
 
-			sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+			sess := newSession(
+				context.Background(),
+				42,
+				nil,
+				mockHTTP3Stream{bytes.NewReader(b)},
+				"",
+				sessionFlowControl{},
+			)
 			select {
 			case <-sess.Context().Done():
 			case <-time.After(time.Second):
@@ -260,7 +274,14 @@ func TestMaxStreamsCapsuleDecreaseClosesSession(t *testing.T) {
 	b := (maxStreamsBidiCapsule{MaximumStreams: maxOutgoingStreams}).Append(nil)
 	b = (maxStreamsBidiCapsule{MaximumStreams: maxOutgoingStreams - 1}).Append(b)
 
-	sess := newSession(context.Background(), 42, nil, mockHTTP3Stream{bytes.NewReader(b)}, "")
+	sess := newSession(
+		context.Background(),
+		42,
+		nil,
+		mockHTTP3Stream{bytes.NewReader(b)},
+		"",
+		sessionFlowControl{Enabled: true, MaxOutgoingStreams: 0},
+	)
 	select {
 	case <-sess.Context().Done():
 	case <-time.After(time.Second):
@@ -282,7 +303,7 @@ func TestSessionSendsQueuedCapsules(t *testing.T) {
 
 	clientStr, err := clientConn.OpenStreamSync(ctx)
 	require.NoError(t, err)
-	sess := newSession(context.Background(), 42, clientConn, quicHTTP3Stream{clientStr}, "")
+	sess := newSession(context.Background(), 42, clientConn, quicHTTP3Stream{clientStr}, "", sessionFlowControl{})
 	sess.queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: 42})
 	sess.queueCapsule(streamsBlockedUniCapsule{MaximumStreams: 1337})
 
@@ -333,7 +354,14 @@ func TestSessionClosesWhenOutgoingCapsuleQueueFull(t *testing.T) {
 	_, err = clientStr.Write(make([]byte, 1450))
 	require.NoError(t, err)
 
-	sess := newSession(context.Background(), 0, clientConn, quicHTTP3Stream{clientStr}, "")
+	sess := newSession(
+		context.Background(),
+		0,
+		clientConn,
+		quicHTTP3Stream{clientStr},
+		"",
+		sessionFlowControl{},
+	)
 	for range maxQueuedOutgoingCapsules {
 		sess.queueCapsule(streamsBlockedBidiCapsule{})
 	}
@@ -389,7 +417,14 @@ func TestCloseWithErrorDropsQueuedCapsulesWhenConnectStreamBlocked(t *testing.T)
 	_, err = clientStr.Write(make([]byte, 1450))
 	require.NoError(t, err)
 
-	sess := newSession(context.Background(), 0, clientConn, quicHTTP3Stream{clientStr}, "")
+	sess := newSession(
+		context.Background(),
+		0,
+		clientConn,
+		quicHTTP3Stream{clientStr},
+		"",
+		sessionFlowControl{},
+	)
 	sess.queueCapsule(streamsBlockedBidiCapsule{})
 
 	done := make(chan error, 1)

--- a/stream_test.go
+++ b/stream_test.go
@@ -208,7 +208,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 
 	sm := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, nil)
 	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) })
-	sm.AddStream(recvStr.StreamID(), str)
+	require.NoError(t, sm.AddStream(recvStr.StreamID(), str))
 
 	// start reading
 	errChan := make(chan error, 1)
@@ -330,7 +330,7 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newOutgoingUniStreamsMap(nil, 0, func(c capsule) {
+	sm := newOutgoingUniStreamsMap(nil, 0, maxOutgoingStreams, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
 	str := newSendStream(sendStr, nil, func() { sm.removeStream(sendStr.StreamID()) })

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -2,9 +2,11 @@ package webtransport
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 )
 
 type acceptQueue[T any] struct {
@@ -88,18 +90,26 @@ func newIncomingStreamsMap[T incomingStream](maxOpenStreams uint64, queueMaxStre
 	}
 }
 
-func (s *incomingStreamsMap[T]) AddStream(id quic.StreamID, str T) {
+func (s *incomingStreamsMap[T]) AddStream(id quic.StreamID, str T) error {
 	s.mx.Lock()
 	if closeErr := context.Cause(s.ctx); closeErr != nil {
 		s.mx.Unlock()
 		str.closeWithSession(closeErr)
-		return
+		return nil
+	}
+	if s.numStreams >= s.maxStreams {
+		s.mx.Unlock()
+		return &http3.Error{
+			ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
+			ErrorMessage: fmt.Sprintf("webtransport: peer opened more than %d streams", s.maxStreams),
+		}
 	}
 	s.numStreams++
 	s.m[id] = str
 	s.mx.Unlock()
 
 	s.acceptQueue.add(str)
+	return nil
 }
 
 func (s *incomingStreamsMap[T]) RemoveStream(id quic.StreamID) {

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +24,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID := clientStr.StreamID()
-	streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) }))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) })))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -41,7 +43,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID = clientStr.StreamID()
-	streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) }))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) })))
 
 	select {
 	case <-serverStr.Context().Done():
@@ -60,7 +62,12 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientUniStr, err := clientConn.AcceptUniStream(ctx)
 	require.NoError(t, err)
 	uniStreamID := clientUniStr.StreamID()
-	uniStreams.AddStream(uniStreamID, newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }))
+	require.NoError(t,
+		uniStreams.AddStream(
+			uniStreamID,
+			newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }),
+		),
+	)
 
 	select {
 	case <-serverUniStr.Context().Done():
@@ -98,8 +105,8 @@ func TestIncomingStreamsMapQueuesMaxStreamsOnRemove(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	streams.AddStream(1, newReceiveStream(nil, nil))
-	streams.AddStream(2, newReceiveStream(nil, nil))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{4}, capsules)
@@ -114,12 +121,20 @@ func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	streams.AddStream(1, newReceiveStream(nil, nil))
-	streams.AddStream(2, newReceiveStream(nil, nil))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
 
 	streams.RemoveStream(2)
 	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
+}
+
+func TestIncomingStreamsMapRejectsStreamOverLimit(t *testing.T) {
+	streams := newIncomingStreamsMap[*ReceiveStream](1, nil)
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
+	err := streams.AddStream(2, newReceiveStream(nil, nil))
+	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
+	require.ErrorContains(t, err, "peer opened more than 1 streams")
 }

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -47,6 +47,7 @@ type outgoingStreamsMap[T outgoingStream] struct {
 }
 
 func newOutgoingStreamsMap[T outgoingStream](
+	maxStreams uint64,
 	openStream func() (T, quic.StreamID, error),
 	openStreamSync func(context.Context) (T, quic.StreamID, error),
 	queueBlocked func(uint64),
@@ -56,15 +57,16 @@ func newOutgoingStreamsMap[T outgoingStream](
 		openStreamSync: openStreamSync,
 		queueBlocked:   queueBlocked,
 		streamCtxs:     make(map[int]context.CancelFunc),
-		maxStreams:     maxOutgoingStreams,
+		maxStreams:     maxStreams,
 		m:              make(map[quic.StreamID]T),
 	}
 }
 
-func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap[*Stream] {
+func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams uint64, queueCapsule func(capsule)) *outgoingStreamsMap[*Stream] {
 	streamHdr := newOutgoingStreamHeader(webTransportFrameType, sessionID)
 	var streams *outgoingStreamsMap[*Stream]
 	streams = newOutgoingStreamsMap(
+		maxStreams,
 		func() (*Stream, quic.StreamID, error) {
 			qstr, err := conn.OpenStream()
 			if err != nil {
@@ -86,10 +88,16 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsul
 	return streams
 }
 
-func newOutgoingUniStreamsMap(conn *quic.Conn, sessionID sessionID, queueCapsule func(capsule)) *outgoingStreamsMap[*SendStream] {
+func newOutgoingUniStreamsMap(
+	conn *quic.Conn,
+	sessionID sessionID,
+	maxStreams uint64,
+	queueCapsule func(capsule),
+) *outgoingStreamsMap[*SendStream] {
 	streamHdr := newOutgoingStreamHeader(webTransportUniStreamType, sessionID)
 	var streams *outgoingStreamsMap[*SendStream]
 	streams = newOutgoingStreamsMap(
+		maxStreams,
 		func() (*SendStream, quic.StreamID, error) {
 			qstr, err := conn.OpenUniStream()
 			if err != nil {

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +22,7 @@ func TestOutgoingStreamsMapOpenStreamSyncClose(t *testing.T) {
 	}
 	openStreamSyncCalled := make(chan struct{}, 1)
 	streams := newOutgoingStreamsMap(
+		1,
 		openStream,
 		func(ctx context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
 			openStreamSyncCalled <- struct{}{}
@@ -29,7 +31,6 @@ func TestOutgoingStreamsMapOpenStreamSyncClose(t *testing.T) {
 		},
 		func(uint64) {},
 	)
-	streams.maxStreams = 1
 
 	errChan := make(chan error, 1)
 	go func() {
@@ -62,6 +63,7 @@ func TestOutgoingStreamsMapOpenStreamSyncBlocksAtLimit(t *testing.T) {
 	blocked := make(chan uint64, 10)
 	openStreamSyncCalled := make(chan struct{}, 1)
 	streams := newOutgoingStreamsMap(
+		0,
 		openStream,
 		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
 			openStreamSyncCalled <- struct{}{}
@@ -69,7 +71,6 @@ func TestOutgoingStreamsMapOpenStreamSyncBlocksAtLimit(t *testing.T) {
 		},
 		func(limit uint64) { blocked <- limit },
 	)
-	streams.maxStreams = 0
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errChan := make(chan error, 1)
@@ -122,6 +123,7 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 	openStreamSyncCalled := make(chan quic.StreamID, 10)
 	releaseOpenStreamSync := make(chan struct{})
 	streams := newOutgoingStreamsMap(
+		3,
 		openStream,
 		func(ctx context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
 			str, id, err := openStream()
@@ -138,7 +140,6 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 		},
 		func(limit uint64) { blocked <- limit },
 	)
-	streams.maxStreams = 3
 	for range 3 {
 		_, err := streams.OpenStream()
 		require.NoError(t, err)
@@ -238,13 +239,13 @@ func TestOutgoingStreamsMapBlockedCapsules(t *testing.T) {
 
 func TestOutgoingStreamsMapUpdateStreamLimitDuplicateAndDecrease(t *testing.T) {
 	streams := newOutgoingStreamsMap(
+		5,
 		func() (*outgoingStreamForTests, quic.StreamID, error) { return &outgoingStreamForTests{}, 0, nil },
 		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) {
 			return &outgoingStreamForTests{}, 0, nil
 		},
 		func(uint64) {},
 	)
-	streams.maxStreams = 5
 
 	err := streams.UpdateStreamLimit(5)
 	require.ErrorIs(t, err, errMaxStreamsNotIncreased)
@@ -264,11 +265,11 @@ func TestOutgoingStreamsMapQueueBlockedCanCloseSession(t *testing.T) {
 	sessionErr := &SessionError{ErrorCode: 1337, Message: "closing"}
 	var streams *outgoingStreamsMap[*outgoingStreamForTests]
 	streams = newOutgoingStreamsMap(
+		0,
 		openStream,
 		func(context.Context) (*outgoingStreamForTests, quic.StreamID, error) { return openStream() },
 		func(uint64) { streams.CloseSession(sessionErr) },
 	)
-	streams.maxStreams = 0
 
 	errChan := make(chan error, 1)
 	go func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable incoming bidirectional and unidirectional stream limits for WebTransport clients and servers.
  - Added flow-control negotiation based on local configuration and peer settings.
  - Stream limits now support disabling, capping, and dynamic credit release as streams are consumed.

- **Bug Fixes**
  - Excess incoming streams are rejected with an appropriate flow-control error.
  - Improved handling when sessions close or stream registration fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Config` to set incoming and outgoing WebTransport stream limits per session
> - Introduces a `Config` struct with `MaxIncomingStreams` and `MaxIncomingUniStreams` fields, usable on both `Server` and `Dialer` to advertise WT stream limits via HTTP/3 SETTINGS.
> - Session flow control is negotiated: limits are only enforced when both peers advertise support via SETTINGS.
> - `incomingStreamsMap.AddStream` now returns an error when the max stream count is exceeded, causing the session to close with `WTFlowControlError`.
> - Outgoing stream map constructors (`newOutgoingBidiStreamsMap`, `newOutgoingUniStreamsMap`) now accept an explicit `maxStreams` parameter instead of using a hardcoded default.
> - Behavioral Change: `ConfigureHTTP3Server` no longer unconditionally sends WT initial stream and data limit settings; these are only sent when `Server.Config` is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6635b59. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->