### PR TITLE
reject stream writes while sending stream headers asynchronously

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -27,14 +27,15 @@ var (
 // A SendStream is a unidirectional WebTransport send stream.
 type SendStream struct {
 	str quicSendStream
+
+	streamHdrMu sync.Mutex
 	// WebTransport stream header.
 	// Set by the constructor, set to nil once sent out.
 	// Might be initialized to nil if this sendStream is part of an incoming bidirectional stream.
-	streamHdr   []byte
-	streamHdrMu sync.Mutex
-	// Set to true when a goroutine is spawned to send the header asynchronously.
-	// This only happens if the stream is closed / reset immediately after creation.
-	sendingHdrAsync bool
+	streamHdr []byte
+	// Set by Close or CancelWrite before sending a pending stream header asynchronously.
+	// Prevents Write from sending payload before the header.
+	writeErr error
 
 	onClose func() // to remove the stream from the streamsMap
 
@@ -108,6 +109,11 @@ func (s *SendStream) handleSessionGoneError() error {
 
 func (s *SendStream) write(b []byte) (int, error) {
 	s.streamHdrMu.Lock()
+	if s.writeErr != nil {
+		err := s.writeErr
+		s.streamHdrMu.Unlock()
+		return 0, err
+	}
 	err := s.maybeSendStreamHeader()
 	s.streamHdrMu.Unlock()
 	if err != nil {
@@ -139,7 +145,7 @@ func (s *SendStream) maybeSendStreamHeader() error {
 func (s *SendStream) CancelWrite(e StreamErrorCode) {
 	// if a Goroutine is already sending the header, return immediately
 	s.streamHdrMu.Lock()
-	if s.sendingHdrAsync {
+	if s.writeErr != nil {
 		s.streamHdrMu.Unlock()
 		return
 	}
@@ -147,7 +153,7 @@ func (s *SendStream) CancelWrite(e StreamErrorCode) {
 	if len(s.streamHdr) > 0 {
 		// Sending the stream header might block if we are blocked by flow control.
 		// Send a stream header async so that CancelWrite can return immediately.
-		s.sendingHdrAsync = true
+		s.writeErr = &StreamError{ErrorCode: e}
 		streamHdr := s.streamHdr
 		s.streamHdr = nil
 		s.streamHdrMu.Unlock()
@@ -180,7 +186,7 @@ func (s *SendStream) closeWithSession(err error) {
 func (s *SendStream) Close() error {
 	// if a Goroutine is already sending the header, return immediately
 	s.streamHdrMu.Lock()
-	if s.sendingHdrAsync {
+	if s.writeErr != nil {
 		s.streamHdrMu.Unlock()
 		return nil
 	}
@@ -188,7 +194,7 @@ func (s *SendStream) Close() error {
 	if len(s.streamHdr) > 0 {
 		// Sending the stream header might block if we are blocked by flow control.
 		// Send a stream header async so that CancelWrite can return immediately.
-		s.sendingHdrAsync = true
+		s.writeErr = errors.New("write on closed stream")
 		streamHdr := s.streamHdr
 		s.streamHdr = nil
 		s.streamHdrMu.Unlock()

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -2,6 +2,7 @@ package webtransport
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -226,5 +227,56 @@ func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 		require.ErrorIs(t, err, sessionErr)
 	case <-time.After(scaleDuration(time.Second)):
 		t.Fatal("Write() should not hang after CloseSession()")
+	}
+}
+
+type blockingHeaderStream struct {
+	unblock chan struct{}
+}
+
+func (s *blockingHeaderStream) Write(b []byte) (int, error) {
+	if string(b) == "hdr" {
+		<-s.unblock
+	}
+	return len(b), nil
+}
+
+func (*blockingHeaderStream) Close() error                     { return nil }
+func (*blockingHeaderStream) CancelWrite(quic.StreamErrorCode) {}
+func (*blockingHeaderStream) Context() context.Context         { return context.Background() }
+func (*blockingHeaderStream) SetWriteDeadline(time.Time) error { return nil }
+func (*blockingHeaderStream) SetReliableBoundary()             {}
+
+func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
+	const errorCode StreamErrorCode = 42
+
+	testCases := []struct {
+		name        string
+		stop        func(*SendStream) error
+		expectedErr error
+	}{
+		{
+			name:        "cancel",
+			stop:        func(s *SendStream) error { s.CancelWrite(errorCode); return nil },
+			expectedErr: &StreamError{ErrorCode: errorCode},
+		},
+		{
+			name:        "close",
+			stop:        (*SendStream).Close,
+			expectedErr: errors.New("write on closed stream"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			qstr := &blockingHeaderStream{unblock: make(chan struct{})}
+			str := newSendStream(qstr, []byte("hdr"), func() {})
+
+			require.NoError(t, tc.stop(str))
+			n, err := str.Write([]byte("payload"))
+			close(qstr.unblock)
+			require.Zero(t, n)
+			require.Equal(t, tc.expectedErr, err)
+		})
 	}
 }


### PR DESCRIPTION
Fixes #327.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject writes to `SendStream` while stream headers are being sent asynchronously
> - Replaces the `sendingHdrAsync` boolean in `SendStream` with a `writeErr` field that records a terminal error set by `Close` or `CancelWrite` when a header send is in flight.
> - `SendStream.write` now checks `writeErr` under `streamHdrMu` and returns it immediately, preventing payload writes after the stream is closed or cancelled.
> - `CancelWrite` sets `writeErr` to a `StreamError` with the caller-provided code; `Close` sets it to `"write on closed stream"`, both before asynchronously completing the header send.
> - Adds `TestSendStreamWriteWhileSendingHeaderAsync` with a `blockingHeaderStream` test double to cover both scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8011ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write-side cancellation and closure behavior during in-progress WebTransport header sending.
  * Ensured `Write` immediately stops and returns the recorded error after `CancelWrite` or `Close`, preventing any further header/payload sending.
  * Updated cancellation/close logic to short-circuit consistently once a write error is set.

* **Tests**
  * Added coverage to verify that payload writes complete safely (with the correct error outcome) when header transmission is still pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->