### PR TITLE
track total data sent on a WebTransport session

### DIFF
--- a/flow_control.go
+++ b/flow_control.go
@@ -1,0 +1,39 @@
+package webtransport
+
+import "sync"
+
+type outgoingDataFlowController struct {
+	mx sync.Mutex
+	// TODO: Update this and notify waiters when WT_MAX_DATA is implemented.
+	maxData   uint64
+	bytesSent uint64
+	updated   chan struct{}
+}
+
+func newOutgoingDataFlowController(maxData uint64) *outgoingDataFlowController {
+	return &outgoingDataFlowController{
+		maxData: maxData,
+		updated: make(chan struct{}),
+	}
+}
+
+func (f *outgoingDataFlowController) AddBytesSent(n uint64) uint64 {
+	f.mx.Lock()
+	defer f.mx.Unlock()
+
+	var added uint64
+	if f.bytesSent < f.maxData {
+		added = min(n, f.maxData-f.bytesSent)
+	}
+	if added > 0 {
+		f.bytesSent += added
+	}
+	return added
+}
+
+func (f *outgoingDataFlowController) NextUpdate() <-chan struct{} {
+	f.mx.Lock()
+	updated := f.updated
+	f.mx.Unlock()
+	return updated
+}

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -1,0 +1,14 @@
+package webtransport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutgoingDataFlowController(t *testing.T) {
+	fc := newOutgoingDataFlowController(10)
+	require.Equal(t, uint64(4), fc.AddBytesSent(4))
+	require.Equal(t, uint64(6), fc.AddBytesSent(10))
+	require.Equal(t, uint64(0), fc.AddBytesSent(1))
+}

--- a/integrationtests/flow_control_test.go
+++ b/integrationtests/flow_control_test.go
@@ -163,6 +163,7 @@ func testUnidirectionalStreamFlowControl(t *testing.T, ctx context.Context, open
 
 func requireStreamOpeningBlocked(t *testing.T, result <-chan error, message string) {
 	t.Helper()
+
 	select {
 	case err := <-result:
 		t.Fatalf("%s: %v", message, err)

--- a/send_stream.go
+++ b/send_stream.go
@@ -13,6 +13,7 @@ import (
 
 type quicSendStream interface {
 	io.WriteCloser
+	WriteWithLimit([]byte, func(int) int) (int, error)
 	CancelWrite(quic.StreamErrorCode)
 	Context() context.Context
 	SetWriteDeadline(time.Time) error
@@ -27,6 +28,7 @@ var (
 // A SendStream is a unidirectional WebTransport send stream.
 type SendStream struct {
 	str quicSendStream
+	fc  *outgoingDataFlowController
 
 	streamHdrMu sync.Mutex
 	// WebTransport stream header.
@@ -48,9 +50,10 @@ type SendStream struct {
 	deadlineNotifyCh chan struct{} // receives a value when deadline changes
 }
 
-func newSendStream(str quicSendStream, hdr []byte, onClose func()) *SendStream {
+func newSendStream(str quicSendStream, hdr []byte, fc *outgoingDataFlowController, onClose func()) *SendStream {
 	return &SendStream{
 		str:       str,
+		fc:        fc,
 		closed:    make(chan struct{}),
 		streamHdr: hdr,
 		onClose:   onClose,
@@ -119,7 +122,67 @@ func (s *SendStream) write(b []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return s.str.Write(b)
+	return s.writeData(b)
+}
+
+func (s *SendStream) writeData(b []byte) (int, error) {
+	if s.fc == nil || len(b) == 0 {
+		return s.str.Write(b)
+	}
+
+	var written int
+	for len(b) > 0 {
+		updated := s.fc.NextUpdate()
+		n, err := s.str.WriteWithLimit(b, func(maxBytes int) int {
+			return int(s.fc.AddBytesSent(uint64(maxBytes)))
+		})
+		b = b[n:]
+		written += n
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, quic.ErrWriteLimitReached) {
+			return written, err
+		}
+		// TODO: Send a WT_DATA_BLOCKED capsule.
+		if err := s.waitForUpdate(updated); err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+func (s *SendStream) waitForUpdate(updated <-chan struct{}) error {
+	s.deadlineMu.Lock()
+	if s.deadlineNotifyCh == nil {
+		s.deadlineNotifyCh = make(chan struct{}, 1)
+	}
+	notifyCh := s.deadlineNotifyCh
+	s.deadlineMu.Unlock()
+
+	for {
+		s.deadlineMu.Lock()
+		deadline := s.writeDeadline
+		s.deadlineMu.Unlock()
+
+		var timerCh <-chan time.Time
+		if !deadline.IsZero() {
+			if d := time.Until(deadline); d > 0 {
+				timerCh = time.After(d)
+			} else {
+				return os.ErrDeadlineExceeded
+			}
+		}
+		select {
+		case <-s.str.Context().Done():
+			return context.Cause(s.str.Context())
+		case <-updated:
+			return nil
+		case <-timerCh:
+			return os.ErrDeadlineExceeded
+		case <-notifyCh:
+		}
+	}
 }
 
 func (s *SendStream) maybeSendStreamHeader() error {

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func TestSendStreamClose(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sendStr, recvStr := newUniStreamPair(t)
 			recvStr.CancelRead(tc.quicErrorCode)
-			str := newSendStream(sendStr, nil, func() {})
+			str := newSendStream(sendStr, nil, nil, func() {})
 
 			// eventually, the stream reset will be received and the write will fail
 			var writeErr error
@@ -59,7 +60,7 @@ func TestSendStreamClose(t *testing.T) {
 
 func TestSendStreamSessionGone(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
-	str := newSendStream(sendStr, nil, func() {})
+	str := newSendStream(sendStr, nil, nil, func() {})
 
 	// simulate remote side sending WTSessionGoneErrorCode
 	recvStr.CancelRead(WTSessionGoneErrorCode)
@@ -94,7 +95,7 @@ func TestSendStreamSessionGone(t *testing.T) {
 func TestSendStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newSendStream(sendStr, nil, func() {})
+		str := newSendStream(sendStr, nil, nil, func() {})
 
 		require.NoError(t, str.SetWriteDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
 		recvStr.CancelRead(WTSessionGoneErrorCode)
@@ -120,7 +121,7 @@ func TestSendStreamSessionGoneDeadline(t *testing.T) {
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newSendStream(sendStr, nil, func() {})
+		str := newSendStream(sendStr, nil, nil, func() {})
 
 		recvStr.CancelRead(WTSessionGoneErrorCode)
 
@@ -162,7 +163,7 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 	require.NoError(t, err)
 
 	hdr := []byte("test-header")
-	str := newSendStream(clientStr, hdr, func() {})
+	str := newSendStream(clientStr, hdr, nil, func() {})
 
 	require.NoError(t, str.SetWriteDeadline(time.Now().Add(-time.Second)))
 
@@ -192,7 +193,7 @@ func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sm := newOutgoingUniStreamsMap(nil, 0, maxOutgoingStreams, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
-	str := newSendStream(sendStr, nil, func() { sm.removeStream(sendStr.StreamID()) })
+	str := newSendStream(sendStr, nil, nil, func() { sm.removeStream(sendStr.StreamID()) })
 	sm.mx.Lock()
 	sm.m[sendStr.StreamID()] = str
 	sm.mx.Unlock()
@@ -246,6 +247,9 @@ func (*blockingHeaderStream) CancelWrite(quic.StreamErrorCode) {}
 func (*blockingHeaderStream) Context() context.Context         { return context.Background() }
 func (*blockingHeaderStream) SetWriteDeadline(time.Time) error { return nil }
 func (*blockingHeaderStream) SetReliableBoundary()             {}
+func (s *blockingHeaderStream) WriteWithLimit(b []byte, limit func(int) int) (int, error) {
+	return s.Write(b)
+}
 
 func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
 	const errorCode StreamErrorCode = 42
@@ -270,7 +274,7 @@ func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			qstr := &blockingHeaderStream{unblock: make(chan struct{})}
-			str := newSendStream(qstr, []byte("hdr"), func() {})
+			str := newSendStream(qstr, []byte("hdr"), nil, func() {})
 
 			require.NoError(t, tc.stop(str))
 			n, err := str.Write([]byte("payload"))
@@ -279,4 +283,19 @@ func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
 			require.Equal(t, tc.expectedErr, err)
 		})
 	}
+}
+
+func TestSendStreamDataFlowControl(t *testing.T) {
+	sendStr, recvStr := newUniStreamPair(t)
+	str := newSendStream(sendStr, []byte("hdr"), newOutgoingDataFlowController(5), func() {})
+
+	require.NoError(t, str.SetWriteDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
+	n, err := str.Write([]byte("abcdefgh"))
+	require.Equal(t, 5, n)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	b := make([]byte, len("hdrabcde"))
+	_, err = io.ReadFull(recvStr, b)
+	require.NoError(t, err)
+	require.Equal(t, "hdrabcde", string(b))
 }

--- a/stream.go
+++ b/stream.go
@@ -23,7 +23,7 @@ type Stream struct {
 
 func newStream(str *quic.Stream, hdr []byte, onClose func()) *Stream {
 	s := &Stream{onClose: onClose}
-	s.sendStr = newSendStream(str, hdr, func() { s.registerClose(true) })
+	s.sendStr = newSendStream(str, hdr, nil, func() { s.registerClose(true) })
 	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) })
 	return s
 }

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -104,7 +104,7 @@ func newOutgoingUniStreamsMap(
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+			return newSendStream(qstr, streamHdr, nil, func() { streams.removeStream(id) }), id, nil
 		},
 		func(ctx context.Context) (*SendStream, quic.StreamID, error) {
 			qstr, err := conn.OpenUniStreamSync(ctx)
@@ -112,7 +112,7 @@ func newOutgoingUniStreamsMap(
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+			return newSendStream(qstr, streamHdr, nil, func() { streams.removeStream(id) }), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedUniCapsule{MaximumStreams: limit}) },
 	)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track total data sent on a WebTransport session with flow control
> - Adds `outgoingDataFlowController` in [`flow_control.go`](https://github.com/quic-go/webtransport-go/pull/329/files#diff-6707e404dc1c141f33d90663dc3fa9842f5f25a67c0f4b75fdccdfddbef82351) with mutex-protected `maxData`/`bytesSent` counters and an update channel to signal when the flow window changes.
> - Adds `writeData` and `waitForUpdate` methods to `SendStream` so writes enforce the flow control window, loop until the buffer is drained or an error occurs, and block waiting for window updates when the limit is reached.
> - `newSendStream` now accepts an `*outgoingDataFlowController` parameter (callers pass `nil` to preserve existing behavior).
> - Risk: writes against a flow-controlled stream may now return partial results and `os.ErrDeadlineExceeded` if the window is exhausted before the deadline, which is a behavioral change for callers that assume full writes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a63bb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outgoing data flow control for send streams.
  * Large writes now pause when the flow limit is reached and resume when capacity becomes available.
  * Write deadlines and stream cancellation remain respected while waiting.

* **Bug Fixes**
  * Prevented send streams from exceeding their permitted outgoing data allowance.

* **Tests**
  * Added coverage for flow-control limits, partial writes, deadlines, and resumed stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->