### PR TITLE
implement sending of WT_DATA_BLOCKED capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -15,6 +15,7 @@ const (
 	maxStreamDataCapsuleType      http3.CapsuleType = 0x190b4d3e // only used on WebTransport over HTTP/2
 	maxStreamsBidiCapsuleType     http3.CapsuleType = 0x190b4d3f
 	maxStreamsUniCapsuleType      http3.CapsuleType = 0x190b4d40
+	dataBlockedCapsuleType        http3.CapsuleType = 0x190b4d41
 	streamDataBlockedCapsuleType  http3.CapsuleType = 0x190b4d42 // only used on WebTransport over HTTP/2
 	streamsBlockedBidiCapsuleType http3.CapsuleType = 0x190b4d43
 	streamsBlockedUniCapsuleType  http3.CapsuleType = 0x190b4d44
@@ -57,6 +58,12 @@ func parseNextCapsule(parser *http3.CapsuleParser) (capsule, error) {
 				return nil, err
 			}
 			return maxStreamsUniCapsule{MaximumStreams: maxStreams}, nil
+		case dataBlockedCapsuleType:
+			maxData, err := parseDataBlockedCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return dataBlockedCapsule{MaximumData: maxData}, nil
 		case streamDataBlockedCapsuleType:
 			return nil, errors.New("WT_STREAM_DATA_BLOCKED capsule received")
 		case streamsBlockedBidiCapsuleType:
@@ -145,6 +152,16 @@ func (c maxStreamsUniCapsule) Append(b []byte) []byte {
 	return quicvarint.Append(b, c.MaximumStreams)
 }
 
+type dataBlockedCapsule struct {
+	MaximumData uint64
+}
+
+func (c dataBlockedCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(dataBlockedCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumData)))
+	return quicvarint.Append(b, c.MaximumData)
+}
+
 type streamsBlockedBidiCapsule struct {
 	MaximumStreams uint64
 }
@@ -163,6 +180,17 @@ func (c streamsBlockedUniCapsule) Append(b []byte) []byte {
 	b = quicvarint.Append(b, uint64(streamsBlockedUniCapsuleType))
 	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumStreams)))
 	return quicvarint.Append(b, c.MaximumStreams)
+}
+
+func parseDataBlockedCapsule(r http3.CapsuleReader) (uint64, error) {
+	maxData, err := quicvarint.Read(r)
+	if err != nil {
+		return 0, err
+	}
+	if r.Remaining() != 0 {
+		return 0, errors.New("WT_DATA_BLOCKED capsule has trailing data")
+	}
+	return maxData, nil
 }
 
 func parseMaxStreamsCapsule(r http3.CapsuleReader) (uint64, error) {

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -55,6 +55,23 @@ func TestCloseSessionCapsuleRoundTrip(t *testing.T) {
 	require.Equal(t, closeSessionCapsule{ErrorCode: 42, Message: "all good"}, c)
 }
 
+func TestDataBlockedCapsuleRoundTrip(t *testing.T) {
+	var b bytes.Buffer
+	c := dataBlockedCapsule{MaximumData: 1337}
+	b.Write(c.Append(nil))
+
+	typ, r, err := http3.NewCapsuleParser(&b).Next()
+	require.NoError(t, err)
+	require.Equal(t, dataBlockedCapsuleType, typ)
+	maxData, err := quicvarint.Read(r)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1337), maxData)
+
+	parsed, err := parseNextCapsule(http3.NewCapsuleParser(bytes.NewReader(c.Append(nil))))
+	require.NoError(t, err)
+	require.Equal(t, c, parsed)
+}
+
 func TestMaxStreamsCapsuleRoundTrip(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -145,6 +162,16 @@ func TestParseStreamsBlockedCapsuleTooLarge(t *testing.T) {
 
 	_, err := parseNextCapsule(http3.NewCapsuleParser(&b))
 	require.ErrorContains(t, err, "WT_STREAMS_BLOCKED value too large")
+}
+
+func TestParseDataBlockedCapsuleTrailingData(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(dataBlockedCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	_, err := parseNextCapsule(http3.NewCapsuleParser(bytes.NewReader(b)))
+	require.ErrorContains(t, err, "WT_DATA_BLOCKED capsule has trailing data")
 }
 
 func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {

--- a/flow_control.go
+++ b/flow_control.go
@@ -5,9 +5,10 @@ import "sync"
 type outgoingDataFlowController struct {
 	mx sync.Mutex
 	// TODO: Update this and notify waiters when WT_MAX_DATA is implemented.
-	maxData   uint64
-	bytesSent uint64
-	updated   chan struct{}
+	maxData       uint64
+	bytesSent     uint64
+	lastBlockedAt uint64
+	updated       chan struct{}
 }
 
 func newOutgoingDataFlowController(maxData uint64) *outgoingDataFlowController {
@@ -29,6 +30,17 @@ func (f *outgoingDataFlowController) AddBytesSent(n uint64) uint64 {
 		f.bytesSent += added
 	}
 	return added
+}
+
+func (f *outgoingDataFlowController) IsNewlyBlocked() (bool, uint64) {
+	f.mx.Lock()
+	defer f.mx.Unlock()
+
+	if f.bytesSent < f.maxData || f.maxData == f.lastBlockedAt {
+		return false, 0
+	}
+	f.lastBlockedAt = f.maxData
+	return true, f.maxData
 }
 
 func (f *outgoingDataFlowController) NextUpdate() <-chan struct{} {

--- a/flow_control.go
+++ b/flow_control.go
@@ -5,24 +5,25 @@ import "sync"
 type outgoingDataFlowController struct {
 	mx sync.Mutex
 	// TODO: Update this and notify waiters when WT_MAX_DATA is implemented.
-	maxData       uint64
-	bytesSent     uint64
-	lastBlockedAt uint64
+	maxData       int64
+	bytesSent     int64
+	lastBlockedAt int64
 	updated       chan struct{}
 }
 
-func newOutgoingDataFlowController(maxData uint64) *outgoingDataFlowController {
+func newOutgoingDataFlowController(maxData int64) *outgoingDataFlowController {
 	return &outgoingDataFlowController{
-		maxData: maxData,
-		updated: make(chan struct{}),
+		maxData:       maxData,
+		lastBlockedAt: -1,
+		updated:       make(chan struct{}),
 	}
 }
 
-func (f *outgoingDataFlowController) AddBytesSent(n uint64) uint64 {
+func (f *outgoingDataFlowController) AddBytesSent(n int64) int64 {
 	f.mx.Lock()
 	defer f.mx.Unlock()
 
-	var added uint64
+	var added int64
 	if f.bytesSent < f.maxData {
 		added = min(n, f.maxData-f.bytesSent)
 	}
@@ -32,7 +33,7 @@ func (f *outgoingDataFlowController) AddBytesSent(n uint64) uint64 {
 	return added
 }
 
-func (f *outgoingDataFlowController) IsNewlyBlocked() (bool, uint64) {
+func (f *outgoingDataFlowController) IsNewlyBlocked() (bool, int64) {
 	f.mx.Lock()
 	defer f.mx.Unlock()
 

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -8,18 +8,29 @@ import (
 
 func TestOutgoingDataFlowController(t *testing.T) {
 	fc := newOutgoingDataFlowController(10)
-	require.Equal(t, uint64(4), fc.AddBytesSent(4))
+	require.Equal(t, int64(4), fc.AddBytesSent(4))
 	blocked, maxData := fc.IsNewlyBlocked()
 	require.False(t, blocked)
 	require.Zero(t, maxData)
 
-	require.Equal(t, uint64(6), fc.AddBytesSent(10))
+	require.Equal(t, int64(6), fc.AddBytesSent(10))
 	blocked, maxData = fc.IsNewlyBlocked()
 	require.True(t, blocked)
-	require.Equal(t, uint64(10), maxData)
+	require.Equal(t, int64(10), maxData)
 
-	require.Equal(t, uint64(0), fc.AddBytesSent(1))
+	require.Equal(t, int64(0), fc.AddBytesSent(1))
 	blocked, maxData = fc.IsNewlyBlocked()
 	require.False(t, blocked)
 	require.Zero(t, maxData)
+}
+
+func TestOutgoingDataFlowControllerBlockedAtZero(t *testing.T) {
+	fc := newOutgoingDataFlowController(0)
+
+	blocked, maxData := fc.IsNewlyBlocked()
+	require.True(t, blocked)
+	require.Zero(t, maxData)
+
+	blocked, _ = fc.IsNewlyBlocked()
+	require.False(t, blocked)
 }

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -9,6 +9,17 @@ import (
 func TestOutgoingDataFlowController(t *testing.T) {
 	fc := newOutgoingDataFlowController(10)
 	require.Equal(t, uint64(4), fc.AddBytesSent(4))
+	blocked, maxData := fc.IsNewlyBlocked()
+	require.False(t, blocked)
+	require.Zero(t, maxData)
+
 	require.Equal(t, uint64(6), fc.AddBytesSent(10))
+	blocked, maxData = fc.IsNewlyBlocked()
+	require.True(t, blocked)
+	require.Equal(t, uint64(10), maxData)
+
 	require.Equal(t, uint64(0), fc.AddBytesSent(1))
+	blocked, maxData = fc.IsNewlyBlocked()
+	require.False(t, blocked)
+	require.Zero(t, maxData)
 }

--- a/send_stream.go
+++ b/send_stream.go
@@ -27,8 +27,9 @@ var (
 
 // A SendStream is a unidirectional WebTransport send stream.
 type SendStream struct {
-	str quicSendStream
-	fc  *outgoingDataFlowController
+	str          quicSendStream
+	fc           *outgoingDataFlowController
+	queueCapsule func(capsule)
 
 	streamHdrMu sync.Mutex
 	// WebTransport stream header.
@@ -50,13 +51,20 @@ type SendStream struct {
 	deadlineNotifyCh chan struct{} // receives a value when deadline changes
 }
 
-func newSendStream(str quicSendStream, hdr []byte, fc *outgoingDataFlowController, onClose func()) *SendStream {
+func newSendStream(
+	str quicSendStream,
+	hdr []byte,
+	fc *outgoingDataFlowController,
+	queueCapsule func(capsule),
+	onClose func(),
+) *SendStream {
 	return &SendStream{
-		str:       str,
-		fc:        fc,
-		closed:    make(chan struct{}),
-		streamHdr: hdr,
-		onClose:   onClose,
+		str:          str,
+		fc:           fc,
+		queueCapsule: queueCapsule,
+		closed:       make(chan struct{}),
+		streamHdr:    hdr,
+		onClose:      onClose,
 	}
 }
 
@@ -144,7 +152,9 @@ func (s *SendStream) writeData(b []byte) (int, error) {
 		if !errors.Is(err, quic.ErrWriteLimitReached) {
 			return written, err
 		}
-		// TODO: Send a WT_DATA_BLOCKED capsule.
+		if blocked, maxData := s.fc.IsNewlyBlocked(); blocked {
+			s.queueCapsule(dataBlockedCapsule{MaximumData: maxData})
+		}
 		if err := s.waitForUpdate(updated); err != nil {
 			return written, err
 		}

--- a/send_stream.go
+++ b/send_stream.go
@@ -142,7 +142,7 @@ func (s *SendStream) writeData(b []byte) (int, error) {
 	for len(b) > 0 {
 		updated := s.fc.NextUpdate()
 		n, err := s.str.WriteWithLimit(b, func(maxBytes int) int {
-			return int(s.fc.AddBytesSent(uint64(maxBytes)))
+			return int(s.fc.AddBytesSent(int64(maxBytes)))
 		})
 		b = b[n:]
 		written += n
@@ -153,7 +153,7 @@ func (s *SendStream) writeData(b []byte) (int, error) {
 			return written, err
 		}
 		if blocked, maxData := s.fc.IsNewlyBlocked(); blocked {
-			s.queueCapsule(dataBlockedCapsule{MaximumData: maxData})
+			s.queueCapsule(dataBlockedCapsule{MaximumData: uint64(maxData)})
 		}
 		if err := s.waitForUpdate(updated); err != nil {
 			return written, err

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -37,7 +37,7 @@ func TestSendStreamClose(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sendStr, recvStr := newUniStreamPair(t)
 			recvStr.CancelRead(tc.quicErrorCode)
-			str := newSendStream(sendStr, nil, nil, func() {})
+			str := newSendStream(sendStr, nil, nil, nil, func() {})
 
 			// eventually, the stream reset will be received and the write will fail
 			var writeErr error
@@ -60,7 +60,7 @@ func TestSendStreamClose(t *testing.T) {
 
 func TestSendStreamSessionGone(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
-	str := newSendStream(sendStr, nil, nil, func() {})
+	str := newSendStream(sendStr, nil, nil, nil, func() {})
 
 	// simulate remote side sending WTSessionGoneErrorCode
 	recvStr.CancelRead(WTSessionGoneErrorCode)
@@ -95,7 +95,7 @@ func TestSendStreamSessionGone(t *testing.T) {
 func TestSendStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newSendStream(sendStr, nil, nil, func() {})
+		str := newSendStream(sendStr, nil, nil, nil, func() {})
 
 		require.NoError(t, str.SetWriteDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
 		recvStr.CancelRead(WTSessionGoneErrorCode)
@@ -121,7 +121,7 @@ func TestSendStreamSessionGoneDeadline(t *testing.T) {
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newSendStream(sendStr, nil, nil, func() {})
+		str := newSendStream(sendStr, nil, nil, nil, func() {})
 
 		recvStr.CancelRead(WTSessionGoneErrorCode)
 
@@ -163,7 +163,7 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 	require.NoError(t, err)
 
 	hdr := []byte("test-header")
-	str := newSendStream(clientStr, hdr, nil, func() {})
+	str := newSendStream(clientStr, hdr, nil, nil, func() {})
 
 	require.NoError(t, str.SetWriteDeadline(time.Now().Add(-time.Second)))
 
@@ -193,7 +193,7 @@ func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sm := newOutgoingUniStreamsMap(nil, 0, maxOutgoingStreams, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
-	str := newSendStream(sendStr, nil, nil, func() { sm.removeStream(sendStr.StreamID()) })
+	str := newSendStream(sendStr, nil, nil, nil, func() { sm.removeStream(sendStr.StreamID()) })
 	sm.mx.Lock()
 	sm.m[sendStr.StreamID()] = str
 	sm.mx.Unlock()
@@ -274,7 +274,7 @@ func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			qstr := &blockingHeaderStream{unblock: make(chan struct{})}
-			str := newSendStream(qstr, []byte("hdr"), nil, func() {})
+			str := newSendStream(qstr, []byte("hdr"), nil, nil, func() {})
 
 			require.NoError(t, tc.stop(str))
 			n, err := str.Write([]byte("payload"))
@@ -287,7 +287,14 @@ func TestSendStreamWriteWhileSendingHeaderAsync(t *testing.T) {
 
 func TestSendStreamDataFlowControl(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
-	str := newSendStream(sendStr, []byte("hdr"), newOutgoingDataFlowController(5), func() {})
+	var capsules []capsule
+	str := newSendStream(
+		sendStr,
+		[]byte("hdr"),
+		newOutgoingDataFlowController(5),
+		func(c capsule) { capsules = append(capsules, c) },
+		func() {},
+	)
 
 	require.NoError(t, str.SetWriteDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
 	n, err := str.Write([]byte("abcdefgh"))
@@ -298,4 +305,9 @@ func TestSendStreamDataFlowControl(t *testing.T) {
 	_, err = io.ReadFull(recvStr, b)
 	require.NoError(t, err)
 	require.Equal(t, "hdrabcde", string(b))
+
+	n, err = str.Write([]byte("fgh"))
+	require.Zero(t, n)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	require.Equal(t, []capsule{dataBlockedCapsule{MaximumData: 5}}, capsules)
 }

--- a/session.go
+++ b/session.go
@@ -235,7 +235,7 @@ func (s *Session) queueCapsule(c capsule) {
 // addIncomingStream adds a bidirectional stream that the remote peer opened
 func (s *Session) addIncomingStream(qstr *quic.Stream) {
 	id := qstr.StreamID()
-	str := newStream(qstr, nil, func() { s.incomingStreams.RemoveStream(id) })
+	str := newStream(qstr, nil, s.queueCapsule, func() { s.incomingStreams.RemoveStream(id) })
 	if err := s.incomingStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)
 		s.closeWithError(err, nil)

--- a/stream.go
+++ b/stream.go
@@ -21,9 +21,9 @@ type Stream struct {
 	onClose                        func()
 }
 
-func newStream(str *quic.Stream, hdr []byte, onClose func()) *Stream {
+func newStream(str *quic.Stream, hdr []byte, queueCapsule func(capsule), onClose func()) *Stream {
 	s := &Stream{onClose: onClose}
-	s.sendStr = newSendStream(str, hdr, nil, func() { s.registerClose(true) })
+	s.sendStr = newSendStream(str, hdr, nil, queueCapsule, func() { s.registerClose(true) })
 	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) })
 	return s
 }

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -24,7 +24,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID := clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) })))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) })))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID = clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, func() { streams.RemoveStream(streamID) })))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) })))
 
 	select {
 	case <-serverStr.Context().Done():

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -73,7 +73,7 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }), id, nil
 		},
 		func(ctx context.Context) (*Stream, quic.StreamID, error) {
 			qstr, err := conn.OpenStreamSync(ctx)
@@ -81,7 +81,7 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, func() { streams.removeStream(id) }), id, nil
+			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: limit}) },
 	)
@@ -104,7 +104,7 @@ func newOutgoingUniStreamsMap(
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, nil, func() { streams.removeStream(id) }), id, nil
+			return newSendStream(qstr, streamHdr, nil, queueCapsule, func() { streams.removeStream(id) }), id, nil
 		},
 		func(ctx context.Context) (*SendStream, quic.StreamID, error) {
 			qstr, err := conn.OpenUniStreamSync(ctx)
@@ -112,7 +112,7 @@ func newOutgoingUniStreamsMap(
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, nil, func() { streams.removeStream(id) }), id, nil
+			return newSendStream(qstr, streamHdr, nil, queueCapsule, func() { streams.removeStream(id) }), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedUniCapsule{MaximumStreams: limit}) },
 	)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement sending of `WT_DATA_BLOCKED` capsules from send streams
> - Adds `dataBlockedCapsule` to [capsule.go](https://github.com/quic-go/webtransport-go/pull/331/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6) with serialization and parsing support for the `WT_DATA_BLOCKED` capsule type (`0x190b4d41`).
> - Adds `IsNewlyBlocked` to `outgoingDataFlowController` in [flow_control.go](https://github.com/quic-go/webtransport-go/pull/331/files#diff-6707e404dc1c141f33d90663dc3fa9842f5f25a67c0f4b75fdccdfddbef82351), returning a one-shot notification when flow control blocks at a new `maxData` level.
> - When `writeData` in [send_stream.go](https://github.com/quic-go/webtransport-go/pull/331/files#diff-0683df4767cffeaa4b1127b3e6027900d06dac7973a80454782e810871af742e) hits `quic.ErrWriteLimitReached`, it calls `IsNewlyBlocked` and enqueues a `dataBlockedCapsule` exactly once per blocked level via a `queueCapsule` callback.
> - Wires `queueCapsule` through `newStream`, `newSendStream`, outgoing stream maps, and `session.addIncomingStream` so all stream types can emit capsules.
> - Behavioral Change: `outgoingDataFlowController` internal counters change from `uint64` to `int64`; `newSendStream` now requires an additional `queueCapsule` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69b4ffd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WebTransport `WT_DATA_BLOCKED` capsules, including parsing and round-trip serialization.
  * Streams now enqueue `WT_DATA_BLOCKED` when flow control newly blocks further writes.
* **Bug Fixes**
  * Flow-control blocking now reports and serializes the correct `MaximumData`.
  * Malformed `WT_DATA_BLOCKED` payloads (trailing bytes or truncated values) are rejected with clear errors.
* **Tests**
  * Added/updated capsule and flow-control tests to cover round-trips, error cases, and “newly blocked” state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->