### PR TITLE
implement handling of WT_MAX_DATA capsules

### DIFF
--- a/capsule.go
+++ b/capsule.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	closeSessionCapsuleType       http3.CapsuleType = 0x2843
+	maxDataCapsuleType            http3.CapsuleType = 0x190b4d3d
 	maxStreamDataCapsuleType      http3.CapsuleType = 0x190b4d3e // only used on WebTransport over HTTP/2
 	maxStreamsBidiCapsuleType     http3.CapsuleType = 0x190b4d3f
 	maxStreamsUniCapsuleType      http3.CapsuleType = 0x190b4d40
@@ -44,6 +45,12 @@ func parseNextCapsule(parser *http3.CapsuleParser) (capsule, error) {
 				return nil, err
 			}
 			return capsule, nil
+		case maxDataCapsuleType:
+			maxData, err := parseMaxDataCapsule(capsuleReader)
+			if err != nil {
+				return nil, err
+			}
+			return maxDataCapsule{MaximumData: maxData}, nil
 		case maxStreamDataCapsuleType:
 			return nil, errors.New("WT_MAX_STREAM_DATA capsule received")
 		case maxStreamsBidiCapsuleType:
@@ -132,6 +139,16 @@ func (c closeSessionCapsule) ToSessionError() *SessionError {
 	}
 }
 
+type maxDataCapsule struct {
+	MaximumData uint64
+}
+
+func (c maxDataCapsule) Append(b []byte) []byte {
+	b = quicvarint.Append(b, uint64(maxDataCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(c.MaximumData)))
+	return quicvarint.Append(b, c.MaximumData)
+}
+
 type maxStreamsBidiCapsule struct {
 	MaximumStreams uint64
 }
@@ -189,6 +206,17 @@ func parseDataBlockedCapsule(r http3.CapsuleReader) (uint64, error) {
 	}
 	if r.Remaining() != 0 {
 		return 0, errors.New("WT_DATA_BLOCKED capsule has trailing data")
+	}
+	return maxData, nil
+}
+
+func parseMaxDataCapsule(r http3.CapsuleReader) (uint64, error) {
+	maxData, err := quicvarint.Read(r)
+	if err != nil {
+		return 0, err
+	}
+	if r.Remaining() != 0 {
+		return 0, errors.New("WT_MAX_DATA capsule has trailing data")
 	}
 	return maxData, nil
 }

--- a/capsule_test.go
+++ b/capsule_test.go
@@ -72,6 +72,23 @@ func TestDataBlockedCapsuleRoundTrip(t *testing.T) {
 	require.Equal(t, c, parsed)
 }
 
+func TestMaxDataCapsuleRoundTrip(t *testing.T) {
+	var b bytes.Buffer
+	c := maxDataCapsule{MaximumData: 1337}
+	b.Write(c.Append(nil))
+
+	typ, r, err := http3.NewCapsuleParser(&b).Next()
+	require.NoError(t, err)
+	require.Equal(t, maxDataCapsuleType, typ)
+	maxData, err := quicvarint.Read(r)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1337), maxData)
+
+	parsed, err := parseNextCapsule(http3.NewCapsuleParser(bytes.NewReader(c.Append(nil))))
+	require.NoError(t, err)
+	require.Equal(t, c, parsed)
+}
+
 func TestMaxStreamsCapsuleRoundTrip(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -172,6 +189,16 @@ func TestParseDataBlockedCapsuleTrailingData(t *testing.T) {
 
 	_, err := parseNextCapsule(http3.NewCapsuleParser(bytes.NewReader(b)))
 	require.ErrorContains(t, err, "WT_DATA_BLOCKED capsule has trailing data")
+}
+
+func TestParseMaxDataCapsuleTrailingData(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(maxDataCapsuleType))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(42)+1))
+	b = quicvarint.Append(b, 42)
+	b = append(b, 0)
+
+	_, err := parseNextCapsule(http3.NewCapsuleParser(bytes.NewReader(b)))
+	require.ErrorContains(t, err, "WT_MAX_DATA capsule has trailing data")
 }
 
 func TestParseMaxStreamsCapsuleTrailingData(t *testing.T) {

--- a/flow_control.go
+++ b/flow_control.go
@@ -1,6 +1,12 @@
 package webtransport
 
-import "sync"
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var errMaxDataNotIncreased = errors.New("webtransport: WT_MAX_DATA capsule didn't increase data limit")
 
 type outgoingDataFlowController struct {
 	mx sync.Mutex
@@ -42,6 +48,20 @@ func (f *outgoingDataFlowController) IsNewlyBlocked() (bool, int64) {
 	}
 	f.lastBlockedAt = f.maxData
 	return true, f.maxData
+}
+
+func (f *outgoingDataFlowController) UpdateMaxData(n uint64) error {
+	f.mx.Lock()
+	defer f.mx.Unlock()
+
+	maxData := int64(n)
+	if maxData <= f.maxData {
+		return fmt.Errorf("%w: current limit: %d, received limit: %d", errMaxDataNotIncreased, f.maxData, maxData)
+	}
+	f.maxData = maxData
+	close(f.updated)
+	f.updated = make(chan struct{})
+	return nil
 }
 
 func (f *outgoingDataFlowController) NextUpdate() <-chan struct{} {

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -22,6 +22,22 @@ func TestOutgoingDataFlowController(t *testing.T) {
 	blocked, maxData = fc.IsNewlyBlocked()
 	require.False(t, blocked)
 	require.Zero(t, maxData)
+
+	updated := fc.NextUpdate()
+	require.ErrorIs(t, fc.UpdateMaxData(10), errMaxDataNotIncreased)
+	select {
+	case <-updated:
+		t.Fatal("rejected update notified waiter")
+	default:
+	}
+
+	require.NoError(t, fc.UpdateMaxData(20))
+	select {
+	case <-updated:
+	default:
+		t.Fatal("increased limit didn't notify waiter")
+	}
+	require.Equal(t, int64(10), fc.AddBytesSent(20))
 }
 
 func TestOutgoingDataFlowControllerBlockedAtZero(t *testing.T) {

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -311,3 +311,46 @@ func TestSendStreamDataFlowControl(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
 	require.Equal(t, []capsule{dataBlockedCapsule{MaximumData: 5}}, capsules)
 }
+
+func TestSendStreamDataFlowControlUpdate(t *testing.T) {
+	sendStr, recvStr := newUniStreamPair(t)
+	fc := newOutgoingDataFlowController(5)
+	blocked := make(chan capsule, 1)
+	str := newSendStream(sendStr, []byte("hdr"), fc, func(c capsule) { blocked <- c }, func() {})
+
+	type writeResult struct {
+		n   int
+		err error
+	}
+	written := make(chan writeResult, 1)
+	go func() {
+		n, err := str.Write([]byte("abcdefgh"))
+		written <- writeResult{n: n, err: err}
+	}()
+
+	select {
+	case c := <-blocked:
+		require.Equal(t, dataBlockedCapsule{MaximumData: 5}, c)
+	case <-time.After(scaleDuration(time.Second)):
+		t.Fatal("write didn't become flow control blocked")
+	}
+	select {
+	case result := <-written:
+		t.Fatalf("write completed while flow control blocked: %d bytes, %v", result.n, result.err)
+	default:
+	}
+
+	require.NoError(t, fc.UpdateMaxData(8))
+	select {
+	case result := <-written:
+		require.Equal(t, 8, result.n)
+		require.NoError(t, result.err)
+	case <-time.After(scaleDuration(time.Second)):
+		t.Fatal("write wasn't unblocked by flow control update")
+	}
+
+	b := make([]byte, len("hdrabcdefgh"))
+	_, err := io.ReadFull(recvStr, b)
+	require.NoError(t, err)
+	require.Equal(t, "hdrabcdefgh", string(b))
+}

--- a/session.go
+++ b/session.go
@@ -58,6 +58,7 @@ type Session struct {
 	incomingUniStreams *incomingStreamsMap[*ReceiveStream]
 	outgoingStreams    *outgoingStreamsMap[*Stream]
 	outgoingUniStreams *outgoingStreamsMap[*SendStream]
+	outgoingDataFC     *outgoingDataFlowController
 }
 
 const (
@@ -124,6 +125,17 @@ func (s *Session) readFromConnectStream() {
 		case closeSessionCapsule:
 			s.closeWithError(c.ToSessionError(), nil)
 			return
+		case maxDataCapsule:
+			if s.outgoingDataFC == nil {
+				continue
+			}
+			if err := s.outgoingDataFC.UpdateMaxData(c.MaximumData); err != nil {
+				s.closeWithError(&http3.Error{
+					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
+					ErrorMessage: err.Error(),
+				}, nil)
+				return
+			}
 		case maxStreamsBidiCapsule:
 			if !s.flowControlEnabled {
 				continue


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement WT_MAX_DATA capsule parsing and flow control handling
> - Adds `maxDataCapsuleType` constant and `maxDataCapsule` struct with serialization in [capsule.go](https://github.com/quic-go/webtransport-go/pull/332/files#diff-fcb26645ce598638fca6816e1387f7465294a2b2becbbeec6fb2128e303ab5e6); `parseNextCapsule` now returns a `maxDataCapsule` instead of skipping `WT_MAX_DATA` capsules.
> - Adds `outgoingDataFlowController.UpdateMaxData` in [flow_control.go](https://github.com/quic-go/webtransport-go/pull/332/files#diff-6707e404dc1c141f33d90663dc3fa9842f5f25a67c0f4b75fdccdfddbef82351) to apply incoming data limit increases and notify blocked writers; non-increasing updates return `errMaxDataNotIncreased`.
> - Extends `Session.readFromConnectStream` in [session.go](https://github.com/quic-go/webtransport-go/pull/332/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac) to call `UpdateMaxData` when a `maxDataCapsule` is received, closing the session with `WTFlowControlErrorCode` on invalid updates.
> - Risk: sessions that previously ignored `WT_MAX_DATA` capsules will now close with an error if a non-increasing limit is received.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4bdea1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for receiving and processing `WT_MAX_DATA` capsules to drive outgoing data flow control.
  * Data transfers can resume when the peer increases the allowed outgoing data limit.
* **Bug Fixes**
  * Rejects `WT_MAX_DATA` updates that do not strictly increase the current limit.
  * Detects malformed `WT_MAX_DATA` capsules with trailing payload data and reports an error.
* **Tests**
  * Added MAX_DATA capsule round-trip and malformed/trailing-data parsing tests.
  * Added concurrency coverage verifying `SendStream` unblocks when `UpdateMaxData` raises the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->