### PR TITLE
implement sending of WT_MAX_DATA capsules

### DIFF
--- a/flow_control.go
+++ b/flow_control.go
@@ -70,3 +70,42 @@ func (f *outgoingDataFlowController) NextUpdate() <-chan struct{} {
 	f.mx.Unlock()
 	return updated
 }
+
+type incomingDataFlowController struct {
+	mx sync.Mutex
+
+	bytesRead         int64
+	maxData           int64
+	receiveWindow     int64
+	queueWindowUpdate func(int64)
+}
+
+func newIncomingDataFlowController(bytesRead, maxData int64, queueWindowUpdate func(int64)) *incomingDataFlowController {
+	return &incomingDataFlowController{
+		bytesRead:         bytesRead,
+		maxData:           maxData,
+		receiveWindow:     maxData - bytesRead,
+		queueWindowUpdate: queueWindowUpdate,
+	}
+}
+
+func (f *incomingDataFlowController) AddBytesRead(n int64) error {
+	f.mx.Lock()
+	defer f.mx.Unlock()
+
+	if n > f.maxData-f.bytesRead {
+		return fmt.Errorf("webtransport: received more than %d bytes of stream data", f.maxData)
+	}
+	f.bytesRead += n
+	if f.maxData-f.bytesRead > 3*f.receiveWindow/4 {
+		return nil
+	}
+
+	maxData := f.bytesRead + f.receiveWindow
+	if maxData == f.maxData {
+		return nil
+	}
+	f.maxData = maxData
+	f.queueWindowUpdate(maxData)
+	return nil
+}

--- a/flow_control.go
+++ b/flow_control.go
@@ -97,7 +97,7 @@ func (f *incomingDataFlowController) AddBytesRead(n int64) error {
 		return fmt.Errorf("webtransport: received more than %d bytes of stream data", f.maxData)
 	}
 	f.bytesRead += n
-	if f.maxData-f.bytesRead > 3*f.receiveWindow/4 {
+	if f.maxData-f.bytesRead > f.receiveWindow-f.receiveWindow/4 {
 		return nil
 	}
 

--- a/flow_control_test.go
+++ b/flow_control_test.go
@@ -50,3 +50,14 @@ func TestOutgoingDataFlowControllerBlockedAtZero(t *testing.T) {
 	blocked, _ = fc.IsNewlyBlocked()
 	require.False(t, blocked)
 }
+
+func TestIncomingDataFlowController(t *testing.T) {
+	var updates []int64
+	fc := newIncomingDataFlowController(0, 8, func(maxData int64) { updates = append(updates, maxData) })
+
+	require.NoError(t, fc.AddBytesRead(1))
+	require.Empty(t, updates)
+	require.NoError(t, fc.AddBytesRead(1))
+	require.Equal(t, []int64{10}, updates)
+	require.Error(t, fc.AddBytesRead(9))
+}

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -13,6 +13,7 @@ import (
 type quicReceiveStream interface {
 	io.Reader
 	CancelRead(quic.StreamErrorCode)
+	SetReceiveFinalSizeCallback(func(int64))
 	SetReadDeadline(time.Time) error
 }
 
@@ -24,6 +25,12 @@ var (
 // A ReceiveStream is a unidirectional WebTransport receive stream.
 type ReceiveStream struct {
 	str quicReceiveStream
+	fc  *incomingDataFlowController
+
+	flowControlMx      sync.Mutex
+	bytesRead          int64 // QUIC stream bytes consumed, including the WebTransport stream header
+	finalSizeKnown     bool
+	onFlowControlError func(error)
 
 	onClose func() // to remove the stream from the streamsMap
 
@@ -36,12 +43,25 @@ type ReceiveStream struct {
 	deadlineNotifyCh chan struct{} // receives a value when deadline changes
 }
 
-func newReceiveStream(str quicReceiveStream, onClose func()) *ReceiveStream {
-	return &ReceiveStream{
-		str:     str,
-		closed:  make(chan struct{}),
-		onClose: onClose,
+func newReceiveStream(
+	str quicReceiveStream,
+	onClose func(),
+	fc *incomingDataFlowController,
+	onFlowControlError func(error),
+	streamHeaderLen int64,
+) *ReceiveStream {
+	s := &ReceiveStream{
+		str:                str,
+		fc:                 fc,
+		bytesRead:          streamHeaderLen,
+		onFlowControlError: onFlowControlError,
+		closed:             make(chan struct{}),
+		onClose:            onClose,
 	}
+	if fc != nil {
+		str.SetReceiveFinalSizeCallback(s.onReceiveFinalSize)
+	}
+	return s
 }
 
 // Read reads data from the stream.
@@ -49,6 +69,17 @@ func newReceiveStream(str quicReceiveStream, onClose func()) *ReceiveStream {
 // If the stream was canceled, the error is a [StreamError].
 func (s *ReceiveStream) Read(b []byte) (int, error) {
 	n, err := s.str.Read(b)
+	if s.fc != nil {
+		newlyRead := int64(n)
+		s.flowControlMx.Lock()
+		if !s.finalSizeKnown {
+			s.bytesRead += newlyRead
+		} else {
+			newlyRead = 0
+		}
+		s.flowControlMx.Unlock()
+		s.addBytesRead(newlyRead)
+	}
 	var strErr *quic.StreamError
 	if errors.As(err, &strErr) && strErr.ErrorCode == WTSessionGoneErrorCode {
 		err = s.handleSessionGoneError()
@@ -57,6 +88,25 @@ func (s *ReceiveStream) Read(b []byte) (int, error) {
 		s.onClose()
 	}
 	return n, maybeConvertStreamError(err)
+}
+
+func (s *ReceiveStream) onReceiveFinalSize(size int64) {
+	s.flowControlMx.Lock()
+	n := size - s.bytesRead
+	s.bytesRead = size
+	s.finalSizeKnown = true
+	s.flowControlMx.Unlock()
+
+	s.addBytesRead(n)
+}
+
+func (s *ReceiveStream) addBytesRead(n int64) {
+	if s.fc == nil || n == 0 {
+		return
+	}
+	if err := s.fc.AddBytesRead(n); err != nil && s.onFlowControlError != nil {
+		s.onFlowControlError(err)
+	}
 }
 
 // handleSessionGoneError waits for the session to be closed after receiving a WTSessionGoneErrorCode.

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestReceiveStreamSessionGone(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
-	str := newReceiveStream(recvStr, func() {})
+	str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
 
 	// simulate remote side sending WTSessionGoneErrorCode
 	sendStr.CancelWrite(WTSessionGoneErrorCode)
@@ -46,7 +46,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
 	sm := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, nil)
-	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) })
+	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) }, nil, nil, 0)
 	require.NoError(t, sm.AddStream(recvStr.StreamID(), str))
 
 	// start reading
@@ -80,7 +80,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newReceiveStream(recvStr, func() {})
+		str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
 
 		require.NoError(t, str.SetReadDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
 		sendStr.CancelWrite(WTSessionGoneErrorCode)
@@ -103,7 +103,7 @@ func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newReceiveStream(recvStr, func() {})
+		str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
 
 		sendStr.CancelWrite(WTSessionGoneErrorCode)
 
@@ -155,7 +155,7 @@ func TestReceiveStreamClose(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sendStr, recvStr := newUniStreamPair(t)
 			sendStr.CancelWrite(tc.quicErrorCode)
-			str := newReceiveStream(recvStr, func() {})
+			str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
 
 			_, readErr := io.ReadFull(str, make([]byte, 100))
 
@@ -166,4 +166,36 @@ func TestReceiveStreamClose(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReceiveStreamDataFlowControl(t *testing.T) {
+	sendStr, recvStr := newUniStreamPair(t)
+	updates := make(chan int64, 1)
+	fc := newIncomingDataFlowController(0, 8, func(maxData int64) { updates <- maxData })
+	str := newReceiveStream(recvStr, func() {}, fc, func(error) {}, 3) // newUniStreamPair already consumed a 3-byte stream header
+
+	_, err := sendStr.Write([]byte("1"))
+	require.NoError(t, err)
+	n, err := str.Read(make([]byte, 1))
+	require.Equal(t, 1, n)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fc.bytesRead)
+
+	_, err = sendStr.Write([]byte("234567"))
+	require.NoError(t, err)
+	_, err = recvStr.Peek(make([]byte, 6))
+	require.NoError(t, err)
+	sendStr.CancelWrite(webtransportCodeToHTTPCode(1))
+	select {
+	case update := <-updates:
+		require.Equal(t, int64(15), update)
+	case <-time.After(time.Second):
+		t.Fatal("flow control window wasn't updated")
+	}
+
+	n, err = str.Read(make([]byte, 8))
+	require.Zero(t, n)
+	var streamErr *StreamError
+	require.ErrorAs(t, err, &streamErr)
+	require.Equal(t, int64(7), fc.bytesRead)
 }

--- a/session.go
+++ b/session.go
@@ -257,7 +257,7 @@ func (s *Session) addIncomingStream(qstr *quic.Stream) {
 // addIncomingUniStream adds a unidirectional stream that the remote peer opened
 func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
 	id := qstr.StreamID()
-	str := newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) })
+	str := newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) }, nil, nil, 0)
 	if err := s.incomingUniStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)
 		s.closeWithError(err, nil)

--- a/stream.go
+++ b/stream.go
@@ -24,7 +24,7 @@ type Stream struct {
 func newStream(str *quic.Stream, hdr []byte, queueCapsule func(capsule), onClose func()) *Stream {
 	s := &Stream{onClose: onClose}
 	s.sendStr = newSendStream(str, hdr, nil, queueCapsule, func() { s.registerClose(true) })
-	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) })
+	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) }, nil, nil, 0)
 	return s
 }
 

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -65,7 +65,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	require.NoError(t,
 		uniStreams.AddStream(
 			uniStreamID,
-			newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }),
+			newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }, nil, nil, 0),
 		),
 	)
 
@@ -105,8 +105,8 @@ func TestIncomingStreamsMapQueuesMaxStreamsOnRemove(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
-	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil)))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{4}, capsules)
@@ -121,8 +121,8 @@ func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
-	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil)))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
@@ -133,8 +133,8 @@ func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
 
 func TestIncomingStreamsMapRejectsStreamOverLimit(t *testing.T) {
 	streams := newIncomingStreamsMap[*ReceiveStream](1, nil)
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil)))
-	err := streams.AddStream(2, newReceiveStream(nil, nil))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
+	err := streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0))
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
 	require.ErrorContains(t, err, "peer opened more than 1 streams")
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `WT_MAX_DATA` capsule sending via incoming data flow control
> - Adds `incomingDataFlowController` in [flow_control.go](https://github.com/quic-go/webtransport-go/pull/333/files#diff-6707e404dc1c141f33d90663dc3fa9842f5f25a67c0f4b75fdccdfddbef82351) to track bytes read against a max, expanding the receive window by one window size when available space drops to 25% or below, and invoking a `queueWindowUpdate` callback with the new max.
> - Extends `ReceiveStream` in [receive_stream.go](https://github.com/quic-go/webtransport-go/pull/333/files#diff-64d427149d1560f49d2c53dcd126759f078d0bd308a251ed5ab965a2c5e5dc1d) to optionally wire up a flow controller, tracking bytes consumed (including stream header bytes) and forwarding increments to the controller after each `Read`.
> - Adds `onReceiveFinalSize` callback on `ReceiveStream` so remaining unaccounted bytes are forwarded to the controller when the stream's final size becomes known.
> - Updates `newReceiveStream` signature across [session.go](https://github.com/quic-go/webtransport-go/pull/333/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac), [stream.go](https://github.com/quic-go/webtransport-go/pull/333/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90), and test files to accept the new optional controller, error callback, and header length (nil/0 preserves prior behavior).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00a69e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive incoming stream flow-control budgeting to manage receive-side data consumption.
  * Added receive-window updates triggered as stream bytes are accounted.
  * Incorporated final-size notifications into ongoing byte tracking.
* **Bug Fixes**
  * Prevented flow-control accounting from exceeding the remaining receive allowance.
  * Ceased additional byte accounting once the final size is known.
* **Tests**
  * Added unit tests for incoming flow controller behavior and receive-stream flow-control exhaustion.
  * Updated existing receive-stream/session tests to match the new receive-stream setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->