### PR TITLE
ci: run tests with race detector, fix race condition in test

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,6 +24,10 @@ jobs:
         env:
           TIMESCALE_FACTOR: 10
         run: go test -v -cover -coverprofile coverage.txt ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out report.xml
+      - name: Run tests with race detector
+        env:
+          TIMESCALE_FACTOR: 10
+        run: go test -race -v -shuffle on ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:

--- a/webtransport_test.go
+++ b/webtransport_test.go
@@ -226,9 +226,9 @@ func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverPro
 		},
 	}
 	defer s.Close()
-	var serverProtocol string
+	serverProtocol := make(chan string, 1)
 	addHandler(t, s, func(sess *webtransport.Session) {
-		serverProtocol = sess.SessionState().ApplicationProtocol
+		serverProtocol <- sess.SessionState().ApplicationProtocol
 	})
 
 	addr, closeServer := runServer(t, s)
@@ -249,7 +249,7 @@ func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverPro
 	defer sess.CloseWithError(0, "")
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
 
-	assert.Equal(t, expected, serverProtocol)
+	assert.Equal(t, expected, <-serverProtocol)
 	assert.Equal(t, expected, sess.SessionState().ApplicationProtocol)
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Run tests with race detector in CI and fix race condition in `testApplicationProtocolNegotiation`
- Adds a second test pass to the unit CI job ([unit.yml](.github/workflows/unit.yml)) using `go test -race -v -shuffle on ./...` with `TIMESCALE_FACTOR=10` to catch data races.
- Fixes a race condition in [webtransport_test.go](https://github.com/quic-go/webtransport-go/pull/334/files#diff-db367bcaf9b172479f3cd9d9e7cbb5ca395e4d86b695f83d29e634b1e90328c0) by replacing a shared string variable with a buffered channel, so the handler and test assertion are properly synchronized.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2045d08.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated race-condition testing across the Go test suite.
  * Improved protocol negotiation test reliability by eliminating a concurrency-related test race.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->