### PR TITLE
split up unit and integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,21 +20,29 @@ jobs:
       - run: go version
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
-      - name: Run tests
+      - name: Run unit tests
         env:
           TIMESCALE_FACTOR: 10
-        run: go test -v -cover -coverprofile coverage.txt ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out report.xml
-      - name: Run tests with race detector
+        run: go test -v -cover -coverprofile unit-coverage.txt . ./example/... ./interop/... ./interop_chrome 2>&1 | go-junit-report -set-exit-code -iocopy -out unit-report.xml
+      - name: Run unit tests with race detector
         env:
           TIMESCALE_FACTOR: 10
-        run: go test -race -v -shuffle on ./...
+        run: go test -race -v -shuffle on . ./example/... ./interop/... ./interop_chrome
+      - name: Run integration tests
+        env:
+          TIMESCALE_FACTOR: 10
+        run: go test -v ./integrationtests 2>&1 | go-junit-report -set-exit-code -iocopy -out integration-report.xml
+      - name: Run integration tests with race detector
+        env:
+          TIMESCALE_FACTOR: 10
+        run: go test -race -v -shuffle on ./integrationtests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           OS: ${{ matrix.os }}
           GO: ${{ matrix.go }}
         with:
-          files: coverage.txt
+          files: unit-coverage.txt
           env_vars: OS,GO
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test report to Codecov
@@ -45,7 +53,7 @@ jobs:
           GO: ${{ matrix.go }}
         with:
           report_type: test_results
-          name: Unit tests
-          files: report.xml
+          name: Tests
+          files: unit-report.xml,integration-report.xml
           env_vars: OS,GO
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/integrationtests/flow_control_test.go
+++ b/integrationtests/flow_control_test.go
@@ -1,4 +1,4 @@
-package webtransport_test
+package integrationtests
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
+	"github.com/quic-go/webtransport-go/internal/testdata"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,14 +43,14 @@ func testStreamFlowControl(t *testing.T, clientOpens, unidirectional bool) {
 
 	serverSessionChan := make(chan *webtransport.Session, 1)
 	server := &webtransport.Server{
-		H3:     &http3.Server{TLSConfig: webtransport.TLSConf},
+		H3:     &http3.Server{TLSConfig: testdata.TLSConf},
 		Config: config,
 	}
 	addHandler(t, server, func(sess *webtransport.Session) { serverSessionChan <- sess })
 	addr, closeServer := runServer(t, server)
 
 	dialer := &webtransport.Dialer{
-		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		Config:          config,
 	}
 	defer func() {

--- a/integrationtests/webtransport_test.go
+++ b/integrationtests/webtransport_test.go
@@ -1,4 +1,4 @@
-package webtransport_test
+package integrationtests
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/quic-go/webtransport-go"
+	"github.com/quic-go/webtransport-go/internal/testdata"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -25,6 +27,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func scaleDuration(d time.Duration) time.Duration {
+	if os.Getenv("CI") != "" {
+		return 5 * d
+	}
+	return d
+}
 
 func runServer(t *testing.T, s *webtransport.Server) (addr *net.UDPAddr, close func()) {
 	laddr, err := net.ResolveUDPAddr("udp", "localhost:0")
@@ -48,7 +57,7 @@ func runServer(t *testing.T, s *webtransport.Server) (addr *net.UDPAddr, close f
 func establishSession(t *testing.T, handler func(*webtransport.Session)) (sess *webtransport.Session, close func()) {
 	s := &webtransport.Server{
 		H3: &http3.Server{
-			TLSConfig: webtransport.TLSConf,
+			TLSConfig: testdata.TLSConf,
 			QUICConfig: &quic.Config{
 				EnableDatagrams:                  true,
 				EnableStreamResetPartialDelivery: true,
@@ -60,7 +69,7 @@ func establishSession(t *testing.T, handler func(*webtransport.Session)) (sess *
 
 	addr, closeServer := runServer(t, s)
 	d := webtransport.Dialer{
-		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig: &quic.Config{
 			EnableDatagrams:                  true,
 			EnableStreamResetPartialDelivery: true,
@@ -169,7 +178,7 @@ func TestApplicationProtocolNegotiationErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &webtransport.Server{
 				H3: &http3.Server{
-					TLSConfig: webtransport.TLSConf,
+					TLSConfig: testdata.TLSConf,
 					QUICConfig: &quic.Config{
 						EnableDatagrams:                  true,
 						EnableStreamResetPartialDelivery: true,
@@ -189,7 +198,7 @@ func TestApplicationProtocolNegotiationErrors(t *testing.T) {
 			defer closeServer()
 
 			d := webtransport.Dialer{
-				TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig: &quic.Config{
 					EnableDatagrams:                  true,
 					EnableStreamResetPartialDelivery: true,
@@ -217,7 +226,7 @@ func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverPro
 	s := &webtransport.Server{
 		ApplicationProtocols: serverProtocols,
 		H3: &http3.Server{
-			TLSConfig: webtransport.TLSConf,
+			TLSConfig: testdata.TLSConf,
 			QUICConfig: &quic.Config{
 				EnableDatagrams:                  true,
 				EnableStreamResetPartialDelivery: true,
@@ -234,7 +243,7 @@ func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverPro
 	addr, closeServer := runServer(t, s)
 	defer closeServer()
 	d := webtransport.Dialer{
-		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig: &quic.Config{
 			EnableDatagrams:                  true,
 			EnableStreamResetPartialDelivery: true,
@@ -395,7 +404,7 @@ func TestUnidirectionalStreams(t *testing.T) {
 func TestMultipleClients(t *testing.T) {
 	const numClients = 5
 	s := &webtransport.Server{
-		H3: &http3.Server{TLSConfig: webtransport.TLSConf},
+		H3: &http3.Server{TLSConfig: testdata.TLSConf},
 	}
 	defer s.Close()
 	addHandler(t, s, newEchoHandler(t))
@@ -409,7 +418,7 @@ func TestMultipleClients(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			d := webtransport.Dialer{
-				TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig: &quic.Config{
 					EnableDatagrams:                  true,
 					EnableStreamResetPartialDelivery: true,
@@ -592,7 +601,7 @@ func TestCheckOrigin(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			s := &webtransport.Server{
-				H3:          &http3.Server{TLSConfig: webtransport.TLSConf},
+				H3:          &http3.Server{TLSConfig: testdata.TLSConf},
 				CheckOrigin: tc.CheckOrigin,
 			}
 			defer s.Close()
@@ -602,7 +611,7 @@ func TestCheckOrigin(t *testing.T) {
 			defer closeServer()
 
 			d := webtransport.Dialer{
-				TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig:      &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
 			}
 			defer d.Close()
@@ -797,7 +806,7 @@ func TestSessionContextValues(t *testing.T) {
 
 	s := &webtransport.Server{
 		H3: &http3.Server{
-			TLSConfig:  webtransport.TLSConf,
+			TLSConfig:  testdata.TLSConf,
 			QUICConfig: &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
 		},
 	}
@@ -821,7 +830,7 @@ func TestSessionContextValues(t *testing.T) {
 	defer closeServer()
 
 	d := webtransport.Dialer{
-		TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool},
+		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig:      &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
 	}
 	defer d.Close()

--- a/internal/testdata/tls.go
+++ b/internal/testdata/tls.go
@@ -1,0 +1,95 @@
+package testdata
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+)
+
+var (
+	TLSConf  *tls.Config
+	CertPool *x509.CertPool
+)
+
+// Use a very long validity period to cover the synthetic clock used in synctest.
+var (
+	notBefore = time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter  = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+func init() {
+	ca, caPrivateKey, err := generateCA()
+	if err != nil {
+		log.Fatal("failed to generate CA certificate:", err)
+	}
+	leafCert, leafPrivateKey, err := generateLeafCert(ca, caPrivateKey)
+	if err != nil {
+		log.Fatal("failed to generate leaf certificate:", err)
+	}
+	CertPool = x509.NewCertPool()
+	CertPool.AddCert(ca)
+	TLSConf = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{leafCert.Raw},
+			PrivateKey:  leafPrivateKey,
+		}},
+		NextProtos: []string{http3.NextProtoH3},
+	}
+}
+
+func generateCA() (*x509.Certificate, *rsa.PrivateKey, error) {
+	certTempl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2019),
+		Subject:               pkix.Name{},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, certTempl, &caPrivateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	ca, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ca, caPrivateKey, nil
+}
+
+func generateLeafCert(ca *x509.Certificate, caPrivateKey *rsa.PrivateKey) (*x509.Certificate, *rsa.PrivateKey, error) {
+	certTempl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		DNSNames:     []string{"localhost"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, certTempl, ca, &privKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, privKey, nil
+}

--- a/server_test.go
+++ b/server_test.go
@@ -33,6 +33,22 @@ func scaleDuration(d time.Duration) time.Duration {
 	return d
 }
 
+func addHandler(t *testing.T, s *webtransport.Server, connHandler func(*webtransport.Session)) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webtransport", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := s.Upgrade(w, r)
+		if err != nil {
+			t.Logf("upgrading failed: %s", err)
+			w.WriteHeader(404)
+			return
+		}
+		connHandler(conn)
+	})
+	s.H3.Handler = mux
+}
+
 func TestUpgradeFailures(t *testing.T) {
 	var s webtransport.Server
 

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -1,102 +1,18 @@
 package webtransport
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"log"
-	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 
-	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/webtransport-go/internal/testdata"
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	TLSConf  *tls.Config
-	CertPool *x509.CertPool
+	TLSConf  = testdata.TLSConf
+	CertPool = testdata.CertPool
 )
-
-// use a very long validity period to cover the synthetic clock used in synctest
-var (
-	notBefore = time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
-	notAfter  = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
-)
-
-func init() {
-	ca, caPrivateKey, err := generateCA()
-	if err != nil {
-		log.Fatal("failed to generate CA certificate:", err)
-	}
-	leafCert, leafPrivateKey, err := generateLeafCert(ca, caPrivateKey)
-	if err != nil {
-		log.Fatal("failed to generate leaf certificate:", err)
-	}
-	CertPool = x509.NewCertPool()
-	CertPool.AddCert(ca)
-	TLSConf = &tls.Config{
-		Certificates: []tls.Certificate{{
-			Certificate: [][]byte{leafCert.Raw},
-			PrivateKey:  leafPrivateKey,
-		}},
-		NextProtos: []string{http3.NextProtoH3},
-	}
-}
-
-func generateCA() (*x509.Certificate, *rsa.PrivateKey, error) {
-	certTempl := &x509.Certificate{
-		SerialNumber:          big.NewInt(2019),
-		Subject:               pkix.Name{},
-		NotBefore:             notBefore,
-		NotAfter:              notAfter,
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-	caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, certTempl, &caPrivateKey.PublicKey, caPrivateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	ca, err := x509.ParseCertificate(caBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ca, caPrivateKey, nil
-}
-
-func generateLeafCert(ca *x509.Certificate, caPrivateKey *rsa.PrivateKey) (*x509.Certificate, *rsa.PrivateKey, error) {
-	certTempl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		DNSNames:     []string{"localhost"},
-		NotBefore:    notBefore,
-		NotAfter:     notAfter,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-	}
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, certTempl, ca, &privKey.PublicKey, caPrivateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	cert, err := x509.ParseCertificate(certBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	return cert, privKey, nil
-}
 
 func NewWebTransportRequest(t *testing.T, addr string) *http.Request {
 	t.Helper()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Separated CI into distinct unit and integration phases, with coverage, race detection, shuffling, and per-phase JUnit reporting.
  - Improved integration test TLS setup by switching to shared synthetic test certificates and scaling timeouts in CI.
  - Simplified server upgrade test wiring for consistent session handling across tests.
- **Chores**
  - Updated coverage and test-result uploads to submit separate unit vs integration artifacts for Codecov.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split unit and integration tests into separate CI jobs
> - The CI workflow now runs unit tests on selected packages (`./example/...`, `./interop/...`, etc.) and integration tests from `./integrationtests` as separate steps, each with and without the race detector.
> - TLS test fixtures are extracted into a new `internal/testdata` package, removing duplicated cert generation from both unit and integration test files.
> - Coverage output is renamed to `unit-coverage.txt` and Codecov now receives two JUnit XML reports: `unit-report.xml` and `integration-report.xml`.
> - A `scaleDuration` helper is added to integration tests to multiply timeouts by 5x when the `CI` environment variable is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f370648. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->