### PR TITLE
README: add MediaMTX, any-sync and socket.io to notable users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ A runnable client and server example is available in [`example`](./example).
 
 | Project | Description | Stars |
 | --- | --- | --- |
+| [any-sync](https://github.com/anyproto/any-sync) | Local-first, peer-to-peer synchronization protocol for encrypted collaborative apps | ![GitHub Repo stars](https://img.shields.io/github/stars/anyproto/any-sync?style=flat-square) |
 | [Centrifugo](https://github.com/centrifugal/centrifugo) | Scalable real-time messaging server in a language-agnostic way. Self-hosted alternative to Pubnub, Pusher, Ably, socket.io, Phoenix.PubSub, SignalR. | ![GitHub Repo stars](https://img.shields.io/github/stars/centrifugal/centrifugo?style=flat-square) |
 | [go-libp2p](https://github.com/libp2p/go-libp2p) | libp2p implementation in Go, powering [Kubo](https://github.com/ipfs/kubo) (IPFS) and [Lotus](https://github.com/filecoin-project/lotus) (Filecoin), among others | ![GitHub Repo stars](https://img.shields.io/github/stars/libp2p/go-libp2p?style=flat-square) |
+| [MediaMTX](https://github.com/bluenviron/mediamtx) | Ready-to-use live media server and media proxy supporting Media-over-QUIC, SRT, WebRTC, RTSP, RTMP, HLS, and more | ![GitHub Repo stars](https://img.shields.io/github/stars/bluenviron/mediamtx?style=flat-square) |
 | [signalr](https://github.com/philippseith/signalr) | SignalR server and client in Go | ![GitHub Repo stars](https://img.shields.io/github/stars/philippseith/signalr?style=flat-square) |
+| [socket.io](https://github.com/zishang520/socket.io) | Socket.IO server and client implementation in Go | ![GitHub Repo stars](https://img.shields.io/github/stars/zishang520/socket.io?style=flat-square) |
 
 If you'd like to see your project added to this list, please send us a PR.
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add MediaMTX, any-sync, and socket.io to notable users in README
Adds three new entries to the 'Projects using webtransport-go' table in [README.md](https://github.com/quic-go/webtransport-go/pull/338/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), each with a project link, description, and GitHub stars badge.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b010a90.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->