### PR TITLE
README: update to draft-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/quic-go/webtransport-go)](https://pkg.go.dev/github.com/quic-go/webtransport-go)
 [![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/webtransport-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/webtransport-go/)
 
-webtransport-go is an implementation of the WebTransport protocol, based on [quic-go](https://github.com/quic-go/quic-go). It currently implements [draft-15](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15.html) of the specification.
+webtransport-go is an implementation of the WebTransport protocol, based on [quic-go](https://github.com/quic-go/quic-go). It currently implements [draft-16](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-16.html) of the specification.
 
 Detailed documentation can be found on [quic-go.net](https://quic-go.net/docs/).
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Update README to reference WebTransport draft-16
Updates the documented WebTransport draft version in [README.md](https://github.com/quic-go/webtransport-go/pull/339/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) from draft-15 to draft-16, including the IETF draft hyperlink.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4499d7e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->