### PR TITLE
add data flow control to the Config, add an integration test

### DIFF
--- a/client.go
+++ b/client.go
@@ -175,12 +175,13 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 					conn.HandleBidirectionalStream(str)
 					return
 				}
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
 				// read the frame type (already peeked above)
-				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+				if _, err := quicvarint.Read(r); err != nil {
 					return
 				}
 				// read the session ID
-				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				id, err := quicvarint.Read(r)
 				if err != nil {
 					return
 				}
@@ -188,7 +189,7 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
-				sessMgr.AddStream(str, sessionID(id))
+				sessMgr.AddStream(str, sessionID(id), r.BytesRead)
 			}()
 		}
 	}()
@@ -209,12 +210,13 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 					conn.HandleUnidirectionalStream(str)
 					return
 				}
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
 				// read the stream type (already peeked above)
-				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+				if _, err := quicvarint.Read(r); err != nil {
 					return
 				}
 				// read the session ID
-				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				id, err := quicvarint.Read(r)
 				if err != nil {
 					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
 					return
@@ -223,7 +225,7 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
-				sessMgr.AddUniStream(str, sessionID(id))
+				sessMgr.AddUniStream(str, sessionID(id), r.BytesRead)
 			}()
 		}
 	}()

--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package webtransport
 
-import "github.com/quic-go/quic-go/http3"
+import (
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+)
 
 // Config contains configuration for a WebTransport client or server.
 type Config struct {
@@ -17,6 +20,13 @@ type Config struct {
 	// If negative, the setting is sent with a value of zero.
 	// Values larger than 2^60 are clipped to 2^60.
 	MaxIncomingUniStreams int64
+
+	// MaxIncomingData is the initial maximum number of bytes that the peer is allowed
+	// to send in WebTransport streams. Stream headers don't count towards this limit.
+	// If zero, SETTINGS_WT_INITIAL_MAX_DATA is not sent.
+	// If negative, the setting is sent with a value of zero.
+	// Values larger than 2^62-1 are clipped to 2^62-1.
+	MaxIncomingData int64
 }
 
 type sessionFlowControl struct {
@@ -26,6 +36,8 @@ type sessionFlowControl struct {
 	MaxIncomingUniStreams uint64
 	MaxOutgoingStreams    uint64
 	MaxOutgoingUniStreams uint64
+	MaxIncomingData       int64
+	MaxOutgoingData       int64
 }
 
 func streamLimit(limit int64) uint64 {
@@ -35,19 +47,27 @@ func streamLimit(limit int64) uint64 {
 	return min(uint64(limit), uint64(maxStreamsLimit))
 }
 
+func dataLimit(limit int64) int64 {
+	return min(max(limit, 0), int64(quicvarint.Max))
+}
+
 func (c Config) addSettings(settings map[uint64]uint64) {
 	delete(settings, settingsWebTransportInitialMaxStreamsBidi)
 	delete(settings, settingsWebTransportInitialMaxStreamsUni)
+	delete(settings, settingsWebTransportInitialMaxData)
 	if c.MaxIncomingStreams != 0 {
 		settings[settingsWebTransportInitialMaxStreamsBidi] = streamLimit(c.MaxIncomingStreams)
 	}
 	if c.MaxIncomingUniStreams != 0 {
 		settings[settingsWebTransportInitialMaxStreamsUni] = streamLimit(c.MaxIncomingUniStreams)
 	}
+	if c.MaxIncomingData != 0 {
+		settings[settingsWebTransportInitialMaxData] = uint64(dataLimit(c.MaxIncomingData))
+	}
 }
 
 func (c Config) sessionFlowControl(remote *http3.Settings) sessionFlowControl {
-	localEnabled := c.MaxIncomingStreams > 0 || c.MaxIncomingUniStreams > 0
+	localEnabled := c.MaxIncomingStreams > 0 || c.MaxIncomingUniStreams > 0 || c.MaxIncomingData > 0
 	if !localEnabled || remote == nil {
 		return sessionFlowControl{}
 	}
@@ -64,5 +84,7 @@ func (c Config) sessionFlowControl(remote *http3.Settings) sessionFlowControl {
 		MaxIncomingUniStreams: streamLimit(c.MaxIncomingUniStreams),
 		MaxOutgoingStreams:    peerSettings[settingsWebTransportInitialMaxStreamsBidi],
 		MaxOutgoingUniStreams: peerSettings[settingsWebTransportInitialMaxStreamsUni],
+		MaxIncomingData:       dataLimit(c.MaxIncomingData),
+		MaxOutgoingData:       int64(peerSettings[settingsWebTransportInitialMaxData]),
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigAddsStreamLimitSettings(t *testing.T) {
+func TestConfigAddsFlowControlSettings(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		config Config
@@ -20,26 +20,29 @@ func TestConfigAddsStreamLimitSettings(t *testing.T) {
 		},
 		{
 			name:   "explicit zero",
-			config: Config{MaxIncomingStreams: -1, MaxIncomingUniStreams: -1},
+			config: Config{MaxIncomingStreams: -1, MaxIncomingUniStreams: -1, MaxIncomingData: -1},
 			want: map[uint64]uint64{
 				settingsWebTransportInitialMaxStreamsBidi: 0,
 				settingsWebTransportInitialMaxStreamsUni:  0,
+				settingsWebTransportInitialMaxData:        0,
 			},
 		},
 		{
 			name:   "positive",
-			config: Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: 20},
+			config: Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: 20, MaxIncomingData: 30},
 			want: map[uint64]uint64{
 				settingsWebTransportInitialMaxStreamsBidi: 10,
 				settingsWebTransportInitialMaxStreamsUni:  20,
+				settingsWebTransportInitialMaxData:        30,
 			},
 		},
 		{
 			name:   "clipped",
-			config: Config{MaxIncomingStreams: 1<<60 + 1, MaxIncomingUniStreams: 1<<60 + 2},
+			config: Config{MaxIncomingStreams: 1<<60 + 1, MaxIncomingUniStreams: 1<<60 + 2, MaxIncomingData: 1 << 62},
 			want: map[uint64]uint64{
 				settingsWebTransportInitialMaxStreamsBidi: maxStreamsLimit,
 				settingsWebTransportInitialMaxStreamsUni:  maxStreamsLimit,
+				settingsWebTransportInitialMaxData:        1<<62 - 1,
 			},
 		},
 	} {
@@ -47,6 +50,7 @@ func TestConfigAddsStreamLimitSettings(t *testing.T) {
 			settings := map[uint64]uint64{
 				settingsWebTransportInitialMaxStreamsBidi: 42,
 				settingsWebTransportInitialMaxStreamsUni:  42,
+				settingsWebTransportInitialMaxData:        42,
 			}
 			tc.config.addSettings(settings)
 			require.Equal(t, tc.want, settings)
@@ -54,11 +58,12 @@ func TestConfigAddsStreamLimitSettings(t *testing.T) {
 	}
 }
 
-func TestConfigNegotiatesStreamFlowControl(t *testing.T) {
-	config := Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: -1}
+func TestConfigNegotiatesFlowControl(t *testing.T) {
+	config := Config{MaxIncomingStreams: 10, MaxIncomingUniStreams: -1, MaxIncomingData: 20}
 	remote := &http3.Settings{Other: map[uint64]uint64{
 		settingsWebTransportInitialMaxStreamsBidi: 3,
 		settingsWebTransportInitialMaxStreamsUni:  4,
+		settingsWebTransportInitialMaxData:        5,
 	}}
 	require.Equal(t, sessionFlowControl{
 		Enabled:               true,
@@ -66,6 +71,8 @@ func TestConfigNegotiatesStreamFlowControl(t *testing.T) {
 		MaxIncomingUniStreams: 0,
 		MaxOutgoingStreams:    3,
 		MaxOutgoingUniStreams: 4,
+		MaxIncomingData:       20,
+		MaxOutgoingData:       5,
 	}, config.sessionFlowControl(remote))
 
 	for _, tc := range []struct {

--- a/flow_control.go
+++ b/flow_control.go
@@ -9,8 +9,7 @@ import (
 var errMaxDataNotIncreased = errors.New("webtransport: WT_MAX_DATA capsule didn't increase data limit")
 
 type outgoingDataFlowController struct {
-	mx sync.Mutex
-	// TODO: Update this and notify waiters when WT_MAX_DATA is implemented.
+	mx            sync.Mutex
 	maxData       int64
 	bytesSent     int64
 	lastBlockedAt int64
@@ -33,9 +32,7 @@ func (f *outgoingDataFlowController) AddBytesSent(n int64) int64 {
 	if f.bytesSent < f.maxData {
 		added = min(n, f.maxData-f.bytesSent)
 	}
-	if added > 0 {
-		f.bytesSent += added
-	}
+	f.bytesSent += added
 	return added
 }
 
@@ -50,11 +47,10 @@ func (f *outgoingDataFlowController) IsNewlyBlocked() (bool, int64) {
 	return true, f.maxData
 }
 
-func (f *outgoingDataFlowController) UpdateMaxData(n uint64) error {
+func (f *outgoingDataFlowController) UpdateMaxData(maxData int64) error {
 	f.mx.Lock()
 	defer f.mx.Unlock()
 
-	maxData := int64(n)
 	if maxData <= f.maxData {
 		return fmt.Errorf("%w: current limit: %d, received limit: %d", errMaxDataNotIncreased, f.maxData, maxData)
 	}

--- a/integrationtests/flow_control_test.go
+++ b/integrationtests/flow_control_test.go
@@ -5,14 +5,53 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"os"
 	"testing"
 	"time"
 
-	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
 	"github.com/quic-go/webtransport-go/internal/testdata"
+
+	"github.com/quic-go/quic-go/http3"
+
 	"github.com/stretchr/testify/require"
 )
+
+func newFlowControlSessions(
+	t *testing.T,
+	ctx context.Context,
+	config *webtransport.Config,
+) (*webtransport.Session, *webtransport.Session) {
+	t.Helper()
+	serverSessionChan := make(chan *webtransport.Session, 1)
+	server := &webtransport.Server{
+		H3:     &http3.Server{TLSConfig: testdata.TLSConf},
+		Config: config,
+	}
+	addHandler(t, server, func(sess *webtransport.Session) { serverSessionChan <- sess })
+	addr, closeServer := runServer(t, server)
+
+	dialer := &webtransport.Dialer{
+		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
+		Config:          config,
+	}
+	t.Cleanup(func() {
+		require.NoError(t, dialer.Close())
+		closeServer()
+	})
+
+	rsp, clientSession, err := dialer.Dial(ctx, fmt.Sprintf("https://localhost:%d/webtransport", addr.Port), nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+
+	var serverSession *webtransport.Session
+	select {
+	case serverSession = <-serverSessionChan:
+	case <-ctx.Done():
+		t.Fatal("server didn't establish the WebTransport session")
+	}
+	return clientSession, serverSession
+}
 
 func TestStreamFlowControl(t *testing.T) {
 	for _, tc := range []struct {
@@ -34,42 +73,15 @@ func TestStreamFlowControl(t *testing.T) {
 func testStreamFlowControl(t *testing.T, clientOpens, unidirectional bool) {
 	const streamLimit = 2
 
-	config := &webtransport.Config{}
+	config := &webtransport.Config{MaxIncomingData: 1024}
 	if unidirectional {
 		config.MaxIncomingUniStreams = streamLimit
 	} else {
 		config.MaxIncomingStreams = streamLimit
 	}
-
-	serverSessionChan := make(chan *webtransport.Session, 1)
-	server := &webtransport.Server{
-		H3:     &http3.Server{TLSConfig: testdata.TLSConf},
-		Config: config,
-	}
-	addHandler(t, server, func(sess *webtransport.Session) { serverSessionChan <- sess })
-	addr, closeServer := runServer(t, server)
-
-	dialer := &webtransport.Dialer{
-		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
-		Config:          config,
-	}
-	defer func() {
-		require.NoError(t, dialer.Close())
-		closeServer()
-	}()
-
 	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(5*time.Second))
 	defer cancel()
-	rsp, clientSession, err := dialer.Dial(ctx, fmt.Sprintf("https://localhost:%d/webtransport", addr.Port), nil)
-	require.NoError(t, err)
-	require.Equal(t, 200, rsp.StatusCode)
-
-	var serverSession *webtransport.Session
-	select {
-	case serverSession = <-serverSessionChan:
-	case <-ctx.Done():
-		t.Fatal("server didn't establish the WebTransport session")
-	}
+	clientSession, serverSession := newFlowControlSessions(t, ctx, config)
 
 	opener, receiver := serverSession, clientSession
 	if clientOpens {
@@ -98,13 +110,13 @@ func testBidirectionalStreamFlowControl(t *testing.T, ctx context.Context, opene
 		_, err := opener.OpenStreamSync(ctx)
 		openResult <- err
 	}()
-	requireStreamOpeningBlocked(t, openResult, "opening a stream unexpectedly completed")
+	requireBlocked(t, openResult, "opening a stream unexpectedly completed")
 
 	const payload = "flow control"
 	_, err = io.WriteString(streams[0], payload)
 	require.NoError(t, err)
 	require.NoError(t, streams[0].Close())
-	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before the peer consumed it")
+	requireBlocked(t, openResult, "opening a stream completed before the peer consumed it")
 
 	str, err := receiver.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -112,7 +124,7 @@ func testBidirectionalStreamFlowControl(t *testing.T, ctx context.Context, opene
 	data, err := io.ReadAll(str)
 	require.NoError(t, err)
 	require.Equal(t, payload, string(data))
-	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before both sides were closed")
+	requireBlocked(t, openResult, "opening a stream completed before both sides were closed")
 	require.NoError(t, str.Close())
 
 	select {
@@ -139,12 +151,12 @@ func testUnidirectionalStreamFlowControl(t *testing.T, ctx context.Context, open
 		_, err := opener.OpenUniStreamSync(ctx)
 		openResult <- err
 	}()
-	requireStreamOpeningBlocked(t, openResult, "opening a stream unexpectedly completed")
+	requireBlocked(t, openResult, "opening a stream unexpectedly completed")
 
 	_, err = io.WriteString(streams[0], "lorem ipsum dolor sit amet")
 	require.NoError(t, err)
 	require.NoError(t, streams[0].Close())
-	requireStreamOpeningBlocked(t, openResult, "opening a stream completed before the peer consumed it")
+	requireBlocked(t, openResult, "opening a stream completed before the peer consumed it")
 
 	str, err := receiver.AcceptUniStream(ctx)
 	require.NoError(t, err)
@@ -161,7 +173,7 @@ func testUnidirectionalStreamFlowControl(t *testing.T, ctx context.Context, open
 	}
 }
 
-func requireStreamOpeningBlocked(t *testing.T, result <-chan error, message string) {
+func requireBlocked(t *testing.T, result <-chan error, message string) {
 	t.Helper()
 
 	select {
@@ -169,4 +181,52 @@ func requireStreamOpeningBlocked(t *testing.T, result <-chan error, message stri
 		t.Fatalf("%s: %v", message, err)
 	case <-time.After(scaleDuration(20 * time.Millisecond)):
 	}
+}
+
+func TestDataFlowControl(t *testing.T) {
+	const payload = "0123456789"
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(time.Second))
+	defer cancel()
+
+	clientSession, serverSession := newFlowControlSessions(t, ctx, &webtransport.Config{
+		MaxIncomingUniStreams: 1,
+		MaxIncomingData:       5,
+	})
+
+	str, err := clientSession.OpenUniStream()
+	require.NoError(t, err)
+	writeResult := make(chan error, 1)
+	go func() {
+		defer str.Close()
+		_, err := io.WriteString(str, payload)
+		writeResult <- err
+	}()
+	requireBlocked(t, writeResult, "writing unexpectedly completed before the peer consumed data")
+
+	recv, err := serverSession.AcceptUniStream(ctx)
+	require.NoError(t, err)
+	data, err := io.ReadAll(recv)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(data))
+
+	select {
+	case err := <-writeResult:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("writing didn't unblock after the peer consumed data")
+	}
+}
+
+func TestDataFlowControlAtZero(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(time.Second))
+	defer cancel()
+
+	clientSession, _ := newFlowControlSessions(t, ctx, &webtransport.Config{MaxIncomingUniStreams: 1})
+	str, err := clientSession.OpenUniStream()
+	require.NoError(t, err)
+	require.NoError(t, str.SetWriteDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
+
+	n, err := io.WriteString(str, "x")
+	require.Zero(t, n)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -1,5 +1,7 @@
 package webtransport
 
+import "io"
+
 const (
 	// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
 	// that was used up until draft-ietf-webtrans-http3-06.
@@ -40,4 +42,18 @@ func isWebTransportProtocol(s string) bool {
 // bidirectional streams, whose QUIC stream IDs are divisible by 4.
 func isValidSessionID(id uint64) bool {
 	return id%4 == 0
+}
+
+type byteCountingReader struct {
+	io.ByteReader
+
+	BytesRead uint64
+}
+
+func (r *byteCountingReader) ReadByte() (byte, error) {
+	b, err := r.ByteReader.ReadByte()
+	if err == nil {
+		r.BytesRead++
+	}
+	return b, err
 }

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -45,10 +45,10 @@ type ReceiveStream struct {
 
 func newReceiveStream(
 	str quicReceiveStream,
+	streamHeaderLen int64,
 	onClose func(),
 	fc *incomingDataFlowController,
 	onFlowControlError func(error),
-	streamHeaderLen int64,
 ) *ReceiveStream {
 	s := &ReceiveStream{
 		str:                str,

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestReceiveStreamSessionGone(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
-	str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
+	str := newReceiveStream(recvStr, 0, func() {}, nil, nil)
 
 	// simulate remote side sending WTSessionGoneErrorCode
 	sendStr.CancelWrite(WTSessionGoneErrorCode)
@@ -46,7 +46,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
 	sm := newIncomingStreamsMap[*ReceiveStream](maxStreamsLimit, nil)
-	str := newReceiveStream(recvStr, func() { sm.RemoveStream(recvStr.StreamID()) }, nil, nil, 0)
+	str := newReceiveStream(recvStr, 0, func() { sm.RemoveStream(recvStr.StreamID()) }, nil, nil)
 	require.NoError(t, sm.AddStream(recvStr.StreamID(), str))
 
 	// start reading
@@ -80,7 +80,7 @@ func TestReceiveStreamReadDuringSessionGoneAndCloseSession(t *testing.T) {
 func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 	t.Run("deadline expires while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
+		str := newReceiveStream(recvStr, 0, func() {}, nil, nil)
 
 		require.NoError(t, str.SetReadDeadline(time.Now().Add(scaleDuration(20*time.Millisecond))))
 		sendStr.CancelWrite(WTSessionGoneErrorCode)
@@ -103,7 +103,7 @@ func TestReceiveStreamSessionGoneDeadline(t *testing.T) {
 
 	t.Run("deadline changed while waiting", func(t *testing.T) {
 		sendStr, recvStr := newUniStreamPair(t)
-		str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
+		str := newReceiveStream(recvStr, 0, func() {}, nil, nil)
 
 		sendStr.CancelWrite(WTSessionGoneErrorCode)
 
@@ -155,7 +155,7 @@ func TestReceiveStreamClose(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sendStr, recvStr := newUniStreamPair(t)
 			sendStr.CancelWrite(tc.quicErrorCode)
-			str := newReceiveStream(recvStr, func() {}, nil, nil, 0)
+			str := newReceiveStream(recvStr, 0, func() {}, nil, nil)
 
 			_, readErr := io.ReadFull(str, make([]byte, 100))
 
@@ -172,7 +172,7 @@ func TestReceiveStreamDataFlowControl(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 	updates := make(chan int64, 1)
 	fc := newIncomingDataFlowController(0, 8, func(maxData int64) { updates <- maxData })
-	str := newReceiveStream(recvStr, func() {}, fc, func(error) {}, 3) // newUniStreamPair already consumed a 3-byte stream header
+	str := newReceiveStream(recvStr, 3, func() {}, fc, func(error) {}) // newUniStreamPair already consumed a 3-byte stream header
 
 	_, err := sendStr.Write([]byte("1"))
 	require.NoError(t, err)

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -190,7 +190,7 @@ func TestSendStreamHeaderRetryAfterDeadlineError(t *testing.T) {
 func TestSendStreamWriteDuringSessionGoneAndCloseSession(t *testing.T) {
 	sendStr, recvStr := newUniStreamPair(t)
 
-	sm := newOutgoingUniStreamsMap(nil, 0, maxOutgoingStreams, func(c capsule) {
+	sm := newOutgoingUniStreamsMap(nil, 0, maxOutgoingStreams, nil, func(c capsule) {
 		t.Fatalf("unexpected capsule: %#v", c)
 	})
 	str := newSendStream(sendStr, nil, nil, nil, func() { sm.removeStream(sendStr.StreamID()) })

--- a/server.go
+++ b/server.go
@@ -249,12 +249,13 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					http3Conn.HandleRequestStream(str)
 					return
 				}
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
 				// read the frame type (already peeked)
-				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+				if _, err := quicvarint.Read(r); err != nil {
 					return
 				}
 				// read the session ID
-				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				id, err := quicvarint.Read(r)
 				if err != nil {
 					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
 					str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
@@ -264,7 +265,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
-				sessMgr.AddStream(str, sessionID(id))
+				sessMgr.AddStream(str, sessionID(id), r.BytesRead)
 			})
 		}
 	}()
@@ -288,7 +289,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					return
 				}
 				// read the stream type (already peeked) before passing to AddUniStream
-				r := quicvarint.NewReader(str)
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
 				if _, err := quicvarint.Read(r); err != nil {
 					return
 				}
@@ -302,7 +303,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
 					return
 				}
-				sessMgr.AddUniStream(str, sessionID(id))
+				sessMgr.AddUniStream(str, sessionID(id), r.BytesRead)
 			})
 		}
 	}()

--- a/session.go
+++ b/session.go
@@ -58,6 +58,7 @@ type Session struct {
 	incomingUniStreams *incomingStreamsMap[*ReceiveStream]
 	outgoingStreams    *outgoingStreamsMap[*Stream]
 	outgoingUniStreams *outgoingStreamsMap[*SendStream]
+	incomingDataFC     *incomingDataFlowController
 	outgoingDataFC     *outgoingDataFlowController
 }
 
@@ -87,7 +88,12 @@ func newSession(
 		ctx:                 ctx,
 		capsuleQueueUpdated: make(chan struct{}, 1),
 	}
-	if !fc.Enabled {
+	if fc.Enabled {
+		c.incomingDataFC = newIncomingDataFlowController(0, fc.MaxIncomingData, func(maxData int64) {
+			c.queueCapsule(maxDataCapsule{MaximumData: uint64(maxData)})
+		})
+		c.outgoingDataFC = newOutgoingDataFlowController(fc.MaxOutgoingData)
+	} else {
 		fc.MaxIncomingStreams = maxStreamsLimit
 		fc.MaxIncomingUniStreams = maxStreamsLimit
 		fc.MaxOutgoingStreams = maxStreamsLimit
@@ -99,8 +105,22 @@ func newSession(
 	c.incomingUniStreams = newIncomingStreamsMap[*ReceiveStream](fc.MaxIncomingUniStreams, func(limit uint64) {
 		c.queueCapsule(maxStreamsUniCapsule{MaximumStreams: limit})
 	})
-	c.outgoingStreams = newOutgoingBidiStreamsMap(conn, sessionID, fc.MaxOutgoingStreams, c.queueCapsule)
-	c.outgoingUniStreams = newOutgoingUniStreamsMap(conn, sessionID, fc.MaxOutgoingUniStreams, c.queueCapsule)
+	c.outgoingStreams = newOutgoingBidiStreamsMap(
+		conn,
+		sessionID,
+		fc.MaxOutgoingStreams,
+		c.outgoingDataFC,
+		c.incomingDataFC,
+		c.queueCapsule,
+		c.closeWithFlowControlError,
+	)
+	c.outgoingUniStreams = newOutgoingUniStreamsMap(
+		conn,
+		sessionID,
+		fc.MaxOutgoingUniStreams,
+		c.outgoingDataFC,
+		c.queueCapsule,
+	)
 
 	go func() {
 		defer ctxCancel()
@@ -129,11 +149,8 @@ func (s *Session) readFromConnectStream() {
 			if s.outgoingDataFC == nil {
 				continue
 			}
-			if err := s.outgoingDataFC.UpdateMaxData(c.MaximumData); err != nil {
-				s.closeWithError(&http3.Error{
-					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
-					ErrorMessage: err.Error(),
-				}, nil)
+			if err := s.outgoingDataFC.UpdateMaxData(int64(c.MaximumData)); err != nil {
+				s.closeWithFlowControlError(err)
 				return
 			}
 		case maxStreamsBidiCapsule:
@@ -141,10 +158,7 @@ func (s *Session) readFromConnectStream() {
 				continue
 			}
 			if err := s.outgoingStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
-				s.closeWithError(&http3.Error{
-					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
-					ErrorMessage: err.Error(),
-				}, nil)
+				s.closeWithFlowControlError(err)
 				return
 			}
 		case maxStreamsUniCapsule:
@@ -152,10 +166,7 @@ func (s *Session) readFromConnectStream() {
 				continue
 			}
 			if err := s.outgoingUniStreams.UpdateStreamLimit(c.MaximumStreams); err != nil {
-				s.closeWithError(&http3.Error{
-					ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
-					ErrorMessage: err.Error(),
-				}, nil)
+				s.closeWithFlowControlError(err)
 				return
 			}
 		case streamsBlockedBidiCapsule, streamsBlockedUniCapsule:
@@ -165,6 +176,13 @@ func (s *Session) readFromConnectStream() {
 			// TODO: log blocked capsules
 		}
 	}
+}
+
+func (s *Session) closeWithFlowControlError(err error) {
+	s.closeWithError(&http3.Error{
+		ErrorCode:    http3.ErrCode(WTFlowControlErrorCode),
+		ErrorMessage: err.Error(),
+	}, nil)
 }
 
 func (s *Session) writeToConnectStream() {
@@ -247,7 +265,16 @@ func (s *Session) queueCapsule(c capsule) {
 // addIncomingStream adds a bidirectional stream that the remote peer opened
 func (s *Session) addIncomingStream(qstr *quic.Stream, streamHeaderLen uint64) {
 	id := qstr.StreamID()
-	str := newStream(qstr, nil, s.queueCapsule, func() { s.incomingStreams.RemoveStream(id) }, int64(streamHeaderLen))
+	str := newStream(
+		qstr,
+		nil,
+		s.outgoingDataFC,
+		s.incomingDataFC,
+		s.queueCapsule,
+		s.closeWithFlowControlError,
+		func() { s.incomingStreams.RemoveStream(id) },
+		int64(streamHeaderLen),
+	)
 	if err := s.incomingStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)
 		s.closeWithError(err, nil)
@@ -261,8 +288,8 @@ func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream, streamHeaderLen
 		qstr,
 		int64(streamHeaderLen),
 		func() { s.incomingUniStreams.RemoveStream(id) },
-		nil,
-		nil,
+		s.incomingDataFC,
+		s.closeWithFlowControlError,
 	)
 	if err := s.incomingUniStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)

--- a/session.go
+++ b/session.go
@@ -245,9 +245,9 @@ func (s *Session) queueCapsule(c capsule) {
 }
 
 // addIncomingStream adds a bidirectional stream that the remote peer opened
-func (s *Session) addIncomingStream(qstr *quic.Stream) {
+func (s *Session) addIncomingStream(qstr *quic.Stream, streamHeaderLen uint64) {
 	id := qstr.StreamID()
-	str := newStream(qstr, nil, s.queueCapsule, func() { s.incomingStreams.RemoveStream(id) })
+	str := newStream(qstr, nil, s.queueCapsule, func() { s.incomingStreams.RemoveStream(id) }, int64(streamHeaderLen))
 	if err := s.incomingStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)
 		s.closeWithError(err, nil)
@@ -255,9 +255,15 @@ func (s *Session) addIncomingStream(qstr *quic.Stream) {
 }
 
 // addIncomingUniStream adds a unidirectional stream that the remote peer opened
-func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
+func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream, streamHeaderLen uint64) {
 	id := qstr.StreamID()
-	str := newReceiveStream(qstr, func() { s.incomingUniStreams.RemoveStream(id) }, nil, nil, 0)
+	str := newReceiveStream(
+		qstr,
+		int64(streamHeaderLen),
+		func() { s.incomingUniStreams.RemoveStream(id) },
+		nil,
+		nil,
+	)
 	if err := s.incomingUniStreams.AddStream(id, str); err != nil {
 		str.closeWithSession(err)
 		s.closeWithError(err, nil)

--- a/session_manager.go
+++ b/session_manager.go
@@ -10,10 +10,15 @@ import (
 )
 
 type unestablishedSession struct {
-	Streams    []*quic.Stream
-	UniStreams []*quic.ReceiveStream
+	Streams    []streamWithHeader[*quic.Stream]
+	UniStreams []streamWithHeader[*quic.ReceiveStream]
 
 	Timer *time.Timer
+}
+
+type streamWithHeader[T any] struct {
+	Stream    T
+	HeaderLen uint64
 }
 
 type sessionEntry struct {
@@ -43,7 +48,7 @@ func newSessionManager(timeout time.Duration) *sessionManager {
 // If the WebTransport session has not yet been established,
 // the stream is buffered until the session is established.
 // If that takes longer than timeout, the stream is reset.
-func (m *sessionManager) AddStream(str *quic.Stream, id sessionID) {
+func (m *sessionManager) AddStream(str *quic.Stream, id sessionID, headerLen uint64) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
@@ -60,11 +65,14 @@ func (m *sessionManager) AddStream(str *quic.Stream, id sessionID) {
 		m.sessions[id] = entry
 	}
 	if entry.Session != nil {
-		entry.Session.addIncomingStream(str)
+		entry.Session.addIncomingStream(str, headerLen)
 		return
 	}
 
-	entry.Unestablished.Streams = append(entry.Unestablished.Streams, str)
+	entry.Unestablished.Streams = append(
+		entry.Unestablished.Streams,
+		streamWithHeader[*quic.Stream]{Stream: str, HeaderLen: headerLen},
+	)
 	m.resetTimer(id)
 }
 
@@ -72,7 +80,7 @@ func (m *sessionManager) AddStream(str *quic.Stream, id sessionID) {
 // If the WebTransport session has not yet been established,
 // the stream is buffered until the session is established.
 // If that takes longer than timeout, the stream is reset.
-func (m *sessionManager) AddUniStream(str *quic.ReceiveStream, id sessionID) {
+func (m *sessionManager) AddUniStream(str *quic.ReceiveStream, id sessionID, headerLen uint64) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
@@ -88,11 +96,14 @@ func (m *sessionManager) AddUniStream(str *quic.ReceiveStream, id sessionID) {
 		m.sessions[id] = entry
 	}
 	if entry.Session != nil {
-		entry.Session.addIncomingUniStream(str)
+		entry.Session.addIncomingUniStream(str, headerLen)
 		return
 	}
 
-	entry.Unestablished.UniStreams = append(entry.Unestablished.UniStreams, str)
+	entry.Unestablished.UniStreams = append(
+		entry.Unestablished.UniStreams,
+		streamWithHeader[*quic.ReceiveStream]{Stream: str, HeaderLen: headerLen},
+	)
 	m.resetTimer(id)
 }
 
@@ -117,11 +128,11 @@ func (m *sessionManager) onTimer(id sessionID) {
 		return
 	}
 	for _, str := range sessionEntry.Unestablished.Streams {
-		str.CancelRead(WTBufferedStreamRejectedErrorCode)
-		str.CancelWrite(WTBufferedStreamRejectedErrorCode)
+		str.Stream.CancelRead(WTBufferedStreamRejectedErrorCode)
+		str.Stream.CancelWrite(WTBufferedStreamRejectedErrorCode)
 	}
 	for _, uniStr := range sessionEntry.Unestablished.UniStreams {
-		uniStr.CancelRead(WTBufferedStreamRejectedErrorCode)
+		uniStr.Stream.CancelRead(WTBufferedStreamRejectedErrorCode)
 	}
 	delete(m.sessions, id)
 }
@@ -138,10 +149,10 @@ func (m *sessionManager) AddSession(id sessionID, s *Session) {
 		// This can happen when we receive streams for this WebTransport session before we complete
 		// the Extended CONNECT request.
 		for _, str := range entry.Unestablished.Streams {
-			s.addIncomingStream(str)
+			s.addIncomingStream(str.Stream, str.HeaderLen)
 		}
 		for _, uniStr := range entry.Unestablished.UniStreams {
-			s.addIncomingUniStream(uniStr)
+			s.addIncomingUniStream(uniStr.Stream, uniStr.HeaderLen)
 		}
 		if entry.Unestablished.Timer != nil {
 			entry.Unestablished.Timer.Stop()

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -99,9 +99,9 @@ func TestSessionManagerAddingStreams(t *testing.T) {
 	// first add the streams...
 	sess := newSession(context.Background(), sessionID, clientConn, reqStr, "", sessionFlowControl{})
 	// ...then add the session
-	sessMgr.AddStream(clientStr, sessionID)
+	sessMgr.AddStream(clientStr, sessionID, 0)
 	require.Equal(t, 1, sessMgr.NumSessions())
-	sessMgr.AddUniStream(clientUniStr, sessionID)
+	sessMgr.AddUniStream(clientUniStr, sessionID, 0)
 	sessMgr.AddSession(sessionID, sess)
 	require.Equal(t, 1, sessMgr.NumSessions())
 
@@ -199,7 +199,7 @@ func TestSessionManagerStreamReordering(t *testing.T) {
 		sessMgr := newSessionManager(timeout)
 		require.Zero(t, sessMgr.NumSessions())
 		// add the first stream
-		sessMgr.AddStream(clientStr1, sessionID)
+		sessMgr.AddStream(clientStr1, sessionID, 0)
 		require.Equal(t, 1, sessMgr.NumSessions())
 		time.Sleep(timeout + time.Second)
 		// the stream should have been reset and the session manager should have no sessions
@@ -207,12 +207,12 @@ func TestSessionManagerStreamReordering(t *testing.T) {
 		_, err = serverStr1.Read([]byte{0})
 		require.ErrorIs(t, err, &quic.StreamError{Remote: true, StreamID: serverStr1.StreamID(), ErrorCode: WTBufferedStreamRejectedErrorCode})
 
-		sessMgr.AddUniStream(clientUniStr1, sessionID)
-		sessMgr.AddUniStream(clientUniStr2, sessionID)
+		sessMgr.AddUniStream(clientUniStr1, sessionID, 0)
+		sessMgr.AddUniStream(clientUniStr2, sessionID, 0)
 		require.Equal(t, 1, sessMgr.NumSessions())
 		time.Sleep(timeout - time.Second)
 		// adding another stream resets the timer
-		sessMgr.AddStream(clientStr2, sessionID)
+		sessMgr.AddStream(clientStr2, sessionID, 0)
 		time.Sleep(timeout - time.Second)
 		require.Equal(t, 1, sessMgr.NumSessions())
 
@@ -224,7 +224,7 @@ func TestSessionManagerStreamReordering(t *testing.T) {
 		// wait for a long time, then add another stream
 		time.Sleep(timeout + time.Second)
 		require.Equal(t, 1, sessMgr.NumSessions())
-		sessMgr.AddUniStream(clientUniStr3, sessionID)
+		sessMgr.AddUniStream(clientUniStr3, sessionID, 0)
 		time.Sleep(timeout + time.Second)
 
 		// the "lorem" stream should have been reset and the "dolor" stream should have been returned
@@ -334,7 +334,7 @@ func TestSessionManagerSessionClose(t *testing.T) {
 			require.NoError(t, err)
 			clientStr, err := clientConn.AcceptStream(context.Background())
 			require.NoError(t, err)
-			sessMgr.AddStream(clientStr, sessID)
+			sessMgr.AddStream(clientStr, sessID, 0)
 			synctest.Wait()
 			// make sure the stream is not rejected
 			select {
@@ -352,7 +352,7 @@ func TestSessionManagerSessionClose(t *testing.T) {
 			require.NoError(t, err)
 			clientUniStr, err := clientConn.AcceptUniStream(context.Background())
 			require.NoError(t, err)
-			sessMgr.AddUniStream(clientUniStr, sessID)
+			sessMgr.AddUniStream(clientUniStr, sessID, 0)
 			synctest.Wait()
 			// make sure the stream is not rejected
 			select {
@@ -371,7 +371,7 @@ func TestSessionManagerSessionClose(t *testing.T) {
 		require.NoError(t, err)
 		clientStrClosed, err := clientConn.AcceptStream(context.Background())
 		require.NoError(t, err)
-		sessMgr.AddStream(clientStrClosed, sessID)
+		sessMgr.AddStream(clientStrClosed, sessID, 0)
 		synctest.Wait()
 		// make sure the stream is immediately rejected
 		_, err = serverStr.Read([]byte{0})
@@ -387,7 +387,7 @@ func TestSessionManagerSessionClose(t *testing.T) {
 		synctest.Wait()
 		clientUniStr, err := clientConn.AcceptUniStream(context.Background())
 		require.NoError(t, err)
-		sessMgr.AddUniStream(clientUniStr, sessID)
+		sessMgr.AddUniStream(clientUniStr, sessID, 0)
 		synctest.Wait()
 		_, err = clientUniStr.Read([]byte{0})
 		require.ErrorIs(t, err, &quic.StreamError{Remote: false, StreamID: clientUniStr.StreamID(), ErrorCode: WTBufferedStreamRejectedErrorCode})

--- a/stream.go
+++ b/stream.go
@@ -21,10 +21,16 @@ type Stream struct {
 	onClose                        func()
 }
 
-func newStream(str *quic.Stream, hdr []byte, queueCapsule func(capsule), onClose func()) *Stream {
+func newStream(
+	str *quic.Stream,
+	hdr []byte,
+	queueCapsule func(capsule),
+	onClose func(),
+	receiveHeaderLen int64,
+) *Stream {
 	s := &Stream{onClose: onClose}
 	s.sendStr = newSendStream(str, hdr, nil, queueCapsule, func() { s.registerClose(true) })
-	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) }, nil, nil, 0)
+	s.recvStr = newReceiveStream(str, receiveHeaderLen, func() { s.registerClose(false) }, nil, nil)
 	return s
 }
 

--- a/stream.go
+++ b/stream.go
@@ -24,13 +24,16 @@ type Stream struct {
 func newStream(
 	str *quic.Stream,
 	hdr []byte,
+	sendFC *outgoingDataFlowController,
+	receiveFC *incomingDataFlowController,
 	queueCapsule func(capsule),
+	onFlowControlError func(error),
 	onClose func(),
 	receiveHeaderLen int64,
 ) *Stream {
 	s := &Stream{onClose: onClose}
-	s.sendStr = newSendStream(str, hdr, nil, queueCapsule, func() { s.registerClose(true) })
-	s.recvStr = newReceiveStream(str, receiveHeaderLen, func() { s.registerClose(false) }, nil, nil)
+	s.sendStr = newSendStream(str, hdr, sendFC, queueCapsule, func() { s.registerClose(true) })
+	s.recvStr = newReceiveStream(str, receiveHeaderLen, func() { s.registerClose(false) }, receiveFC, onFlowControlError)
 	return s
 }
 

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -24,7 +24,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID := clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) })))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID = clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) })))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
 
 	select {
 	case <-serverStr.Context().Done():
@@ -65,7 +65,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	require.NoError(t,
 		uniStreams.AddStream(
 			uniStreamID,
-			newReceiveStream(clientUniStr, func() { uniStreams.RemoveStream(uniStreamID) }, nil, nil, 0),
+			newReceiveStream(clientUniStr, 0, func() { uniStreams.RemoveStream(uniStreamID) }, nil, nil),
 		),
 	)
 
@@ -105,8 +105,8 @@ func TestIncomingStreamsMapQueuesMaxStreamsOnRemove(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
-	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0)))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, 0, nil, nil, nil)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, 0, nil, nil, nil)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{4}, capsules)
@@ -121,8 +121,8 @@ func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
 		capsules = append(capsules, limit)
 	})
 
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
-	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0)))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, 0, nil, nil, nil)))
+	require.NoError(t, streams.AddStream(2, newReceiveStream(nil, 0, nil, nil, nil)))
 
 	streams.RemoveStream(1)
 	require.Equal(t, []uint64{maxStreamsLimit}, capsules)
@@ -133,8 +133,8 @@ func TestIncomingStreamsMapMaxStreamsLimit(t *testing.T) {
 
 func TestIncomingStreamsMapRejectsStreamOverLimit(t *testing.T) {
 	streams := newIncomingStreamsMap[*ReceiveStream](1, nil)
-	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, nil, nil, nil, 0)))
-	err := streams.AddStream(2, newReceiveStream(nil, nil, nil, nil, 0))
+	require.NoError(t, streams.AddStream(1, newReceiveStream(nil, 0, nil, nil, nil)))
+	err := streams.AddStream(2, newReceiveStream(nil, 0, nil, nil, nil))
 	require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCode(WTFlowControlErrorCode)})
 	require.ErrorContains(t, err, "peer opened more than 1 streams")
 }

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -24,7 +24,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err := clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID := clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, nil, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
 
 	str, err := streams.AcceptStream(ctx)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestIncomingStreamsMapAddStreamAfterCloseSession(t *testing.T) {
 	clientStr, err = clientConn.AcceptStream(ctx)
 	require.NoError(t, err)
 	streamID = clientStr.StreamID()
-	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
+	require.NoError(t, streams.AddStream(streamID, newStream(clientStr, nil, nil, nil, nil, nil, func() { streams.RemoveStream(streamID) }, 0)))
 
 	select {
 	case <-serverStr.Context().Done():

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -73,7 +73,7 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }), id, nil
+			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }, 0), id, nil
 		},
 		func(ctx context.Context) (*Stream, quic.StreamID, error) {
 			qstr, err := conn.OpenStreamSync(ctx)
@@ -81,7 +81,7 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }), id, nil
+			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }, 0), id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: limit}) },
 	)

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -62,7 +62,15 @@ func newOutgoingStreamsMap[T outgoingStream](
 	}
 }
 
-func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams uint64, queueCapsule func(capsule)) *outgoingStreamsMap[*Stream] {
+func newOutgoingBidiStreamsMap(
+	conn *quic.Conn,
+	sessionID sessionID,
+	maxStreams uint64,
+	sendFC *outgoingDataFlowController,
+	receiveFC *incomingDataFlowController,
+	queueCapsule func(capsule),
+	onFlowControlError func(error),
+) *outgoingStreamsMap[*Stream] {
 	streamHdr := newOutgoingStreamHeader(webTransportFrameType, sessionID)
 	var streams *outgoingStreamsMap[*Stream]
 	streams = newOutgoingStreamsMap(
@@ -73,7 +81,8 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }, 0), id, nil
+			str := newStream(qstr, streamHdr, sendFC, receiveFC, queueCapsule, onFlowControlError, func() { streams.removeStream(id) }, 0)
+			return str, id, nil
 		},
 		func(ctx context.Context) (*Stream, quic.StreamID, error) {
 			qstr, err := conn.OpenStreamSync(ctx)
@@ -81,7 +90,8 @@ func newOutgoingBidiStreamsMap(conn *quic.Conn, sessionID sessionID, maxStreams 
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newStream(qstr, streamHdr, queueCapsule, func() { streams.removeStream(id) }, 0), id, nil
+			str := newStream(qstr, streamHdr, sendFC, receiveFC, queueCapsule, onFlowControlError, func() { streams.removeStream(id) }, 0)
+			return str, id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedBidiCapsule{MaximumStreams: limit}) },
 	)
@@ -92,6 +102,7 @@ func newOutgoingUniStreamsMap(
 	conn *quic.Conn,
 	sessionID sessionID,
 	maxStreams uint64,
+	fc *outgoingDataFlowController,
 	queueCapsule func(capsule),
 ) *outgoingStreamsMap[*SendStream] {
 	streamHdr := newOutgoingStreamHeader(webTransportUniStreamType, sessionID)
@@ -104,7 +115,8 @@ func newOutgoingUniStreamsMap(
 				return nil, 0, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, nil, queueCapsule, func() { streams.removeStream(id) }), id, nil
+			str := newSendStream(qstr, streamHdr, fc, queueCapsule, func() { streams.removeStream(id) })
+			return str, id, nil
 		},
 		func(ctx context.Context) (*SendStream, quic.StreamID, error) {
 			qstr, err := conn.OpenUniStreamSync(ctx)
@@ -112,7 +124,8 @@ func newOutgoingUniStreamsMap(
 				return nil, invalidStreamID, err
 			}
 			id := qstr.StreamID()
-			return newSendStream(qstr, streamHdr, nil, queueCapsule, func() { streams.removeStream(id) }), id, nil
+			str := newSendStream(qstr, streamHdr, fc, queueCapsule, func() { streams.removeStream(id) })
+			return str, id, nil
 		},
 		func(limit uint64) { queueCapsule(streamsBlockedUniCapsule{MaximumStreams: limit}) },
 	)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable initial incoming data limits for WebTransport sessions, including negotiated inbound/outbound max data.
* **Bug Fixes**
  * Improved flow-control accounting by tracking bytes consumed when parsing WebTransport stream metadata, ensuring accurate enforcement.
  * Refined session flow-control setup and limit updates for CONNECT-stream handling, including consistent error closure.
* **Tests**
  * Added integration coverage for data flow control (blocked writes/unblocking and zero-limit deadline behavior).
  * Updated configuration and session flow-control tests to validate initial max data negotiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add data flow control to WebTransport sessions via `SETTINGS_WT_INITIAL_MAX_DATA`
> - Adds `MaxIncomingData` to [`Config`](https://github.com/quic-go/webtransport-go/pull/340/files#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249) to advertise `SETTINGS_WT_INITIAL_MAX_DATA` and negotiate per-session data flow control limits with peers.
> - Introduces `incomingDataFlowController` and `outgoingDataFlowController` fields to [`Session`](https://github.com/quic-go/webtransport-go/pull/340/files#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccac); sessions now block writers on `WT_MAX_DATA` and send updates as data is consumed.
> - Adds a [`byteCountingReader`](https://github.com/quic-go/webtransport-go/pull/340/files#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38) used in both client and server stream accept loops to track header bytes, ensuring `WT_MAX_DATA` applies only to payload bytes.
> - Propagates header lengths through [`sessionManager`](https://github.com/quic-go/webtransport-go/pull/340/files#diff-8b9c4eec4a8cd39221fe07fbed06dee5abf00c4e641080a3d91424a8f65cd94f) and into stream constructors so early-arriving streams retain correct accounting after session establishment.
> - Adds integration tests [`TestDataFlowControl`](https://github.com/quic-go/webtransport-go/pull/340/files#diff-dd20b8576f18c39e055595909a3b2d1f089f79153c7147afc982801ddae5cdea) and `TestDataFlowControlAtZero` validating backpressure and unblocking on read.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0508d09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->