### PR TITLE
reject pooled sessions without flow control

### DIFF
--- a/server.go
+++ b/server.go
@@ -423,20 +423,32 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 		}
 		w.Header().Add(wtProtocolHeader, v)
 	}
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
 
 	str := w.(http3.HTTPStreamer).HTTPStream()
 	sessID := sessionID(str.StreamID())
+	fc := s.config.sessionFlowControl(settings)
 
 	// The session manager should already exist because ServeQUICConn creates it
 	// before any HTTP requests can be processed on this connection.
 	s.connsMx.Lock()
-	defer s.connsMx.Unlock()
-
 	sessMgr, ok := s.conns[conn]
 	if !ok {
+		s.connsMx.Unlock()
 		return nil, errors.New("webtransport: connection session manager not found")
+	}
+	// Multiple sessions on one HTTP/3 connection require WebTransport flow control.
+	if !fc.Enabled {
+		sessMgr.mx.Lock()
+		for _, entry := range sessMgr.sessions {
+			if entry.Session != nil {
+				sessMgr.mx.Unlock()
+				s.connsMx.Unlock()
+				str.CancelRead(quic.StreamErrorCode(http3.ErrCodeRequestRejected))
+				str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeRequestRejected))
+				return nil, errors.New("webtransport: multiple sessions require flow control")
+			}
+		}
+		sessMgr.mx.Unlock()
 	}
 
 	sess := newSession(
@@ -445,9 +457,13 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 		conn,
 		str,
 		selectedProtocol,
-		s.config.sessionFlowControl(settings),
+		fc,
 	)
 	sessMgr.AddSession(sessID, sess)
+	s.connsMx.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+	w.(http.Flusher).Flush()
 	return sess, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -324,6 +324,52 @@ func TestServerSettingsCheck(t *testing.T) {
 	require.ErrorContains(t, <-errChan, "webtransport: missing datagram support")
 }
 
+func TestServerRejectsPooledSessionWithoutFlowControl(t *testing.T) {
+	s := webtransport.Server{H3: &http3.Server{TLSConfig: webtransport.TLSConf}}
+	defer s.Close()
+
+	s.H3.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = s.Upgrade(w, r)
+	})
+
+	udpConn, err := net.ListenUDP("udp", nil)
+	require.NoError(t, err)
+	defer udpConn.Close()
+	webtransport.ConfigureHTTP3Server(s.H3)
+	go s.Serve(udpConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(time.Second))
+	defer cancel()
+	cconn, err := quic.DialAddr(
+		ctx,
+		fmt.Sprintf("localhost:%d", udpConn.LocalAddr().(*net.UDPAddr).Port),
+		&tls.Config{RootCAs: webtransport.CertPool, NextProtos: []string{http3.NextProtoH3}},
+		&quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+	)
+	require.NoError(t, err)
+	defer cconn.CloseWithError(0, "")
+
+	tr := &http3.Transport{EnableDatagrams: true}
+	conn := tr.NewClientConn(cconn)
+	url := fmt.Sprintf("https://localhost:%d/webtransport", udpConn.LocalAddr().(*net.UDPAddr).Port)
+
+	first, err := conn.OpenRequestStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, first.SendRequestHeader(webtransport.NewWebTransportRequest(t, url)))
+	rsp, err := first.ReadResponse()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+
+	second, err := conn.OpenRequestStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, second.SendRequestHeader(webtransport.NewWebTransportRequest(t, url)))
+	_, err = second.ReadResponse()
+	var streamErr *quic.StreamError
+	require.ErrorAs(t, err, &streamErr)
+	require.True(t, streamErr.Remote)
+	require.Equal(t, quic.StreamErrorCode(http3.ErrCodeRequestRejected), streamErr.ErrorCode)
+}
+
 func TestImmediateClose(t *testing.T) {
 	s := webtransport.Server{H3: &http3.Server{}}
 	require.NoError(t, s.Close())


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reject pooled WebTransport sessions on HTTP/3 connections without flow control
- A second CONNECT request on the same HTTP/3 connection is now rejected with `ErrCodeRequestRejected` unless WebTransport flow control is enabled, matching the spec requirement for session pooling.
- The 200 OK response is now sent only after the session is registered, preventing clients from using a session that hasn't been fully set up.
- A new test in [server_test.go](https://github.com/quic-go/webtransport-go/pull/342/files#diff-53170cac6baf0bf02f3aaa3994259ea4cffaaf2498e768fb7e03cf9f752af96c) verifies the rejection behavior by opening two CONNECT streams without flow control and asserting the second receives a stream error.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8afaefe.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebTransport now rejects additional requests on an existing connection when flow control is disabled.
  * Rejected requests receive the appropriate HTTP/3 request-rejected response, improving connection handling and protocol compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->