### PR TITLE
rename the Dialer to Transport

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -52,7 +52,7 @@ func runClient() error {
 		}
 	}
 
-	cl := &webtransport.Dialer{
+	cl := &webtransport.Transport{
 		ApplicationProtocols: protocols,
 		TLSClientConfig:      tlsConf,
 		QUICConfig: &quic.Config{

--- a/integrationtests/flow_control_test.go
+++ b/integrationtests/flow_control_test.go
@@ -31,7 +31,7 @@ func newFlowControlSessions(
 	addHandler(t, server, func(sess *webtransport.Session) { serverSessionChan <- sess })
 	addr, closeServer := runServer(t, server)
 
-	dialer := &webtransport.Dialer{
+	dialer := &webtransport.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		Config:          config,
 	}

--- a/integrationtests/webtransport_test.go
+++ b/integrationtests/webtransport_test.go
@@ -68,7 +68,7 @@ func establishSession(t *testing.T, handler func(*webtransport.Session)) (sess *
 	addHandler(t, s, handler)
 
 	addr, closeServer := runServer(t, s)
-	d := webtransport.Dialer{
+	d := webtransport.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig: &quic.Config{
 			EnableDatagrams:                  true,
@@ -197,7 +197,7 @@ func TestApplicationProtocolNegotiationErrors(t *testing.T) {
 			addr, closeServer := runServer(t, s)
 			defer closeServer()
 
-			d := webtransport.Dialer{
+			d := webtransport.Transport{
 				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig: &quic.Config{
 					EnableDatagrams:                  true,
@@ -242,7 +242,7 @@ func testApplicationProtocolNegotiation(t *testing.T, clientProtocols, serverPro
 
 	addr, closeServer := runServer(t, s)
 	defer closeServer()
-	d := webtransport.Dialer{
+	d := webtransport.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig: &quic.Config{
 			EnableDatagrams:                  true,
@@ -417,7 +417,7 @@ func TestMultipleClients(t *testing.T) {
 	for range numClients {
 		go func() {
 			defer wg.Done()
-			d := webtransport.Dialer{
+			d := webtransport.Transport{
 				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig: &quic.Config{
 					EnableDatagrams:                  true,
@@ -610,7 +610,7 @@ func TestCheckOrigin(t *testing.T) {
 			addr, closeServer := runServer(t, s)
 			defer closeServer()
 
-			d := webtransport.Dialer{
+			d := webtransport.Transport{
 				TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 				QUICConfig:      &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
 			}
@@ -829,7 +829,7 @@ func TestSessionContextValues(t *testing.T) {
 	addr, closeServer := runServer(t, s)
 	defer closeServer()
 
-	d := webtransport.Dialer{
+	d := webtransport.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: testdata.CertPool},
 		QUICConfig:      &quic.Config{Tracer: qlog.DefaultConnectionTracer, EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
 	}

--- a/interop/client.go
+++ b/interop/client.go
@@ -75,7 +75,7 @@ func RunInteropClient() error {
 		defer keyLog.Close()
 	}
 
-	cl := &webtransport.Dialer{
+	cl := &webtransport.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 			KeyLogWriter:       keyLog,

--- a/transport.go
+++ b/transport.go
@@ -18,7 +18,7 @@ import (
 	"github.com/dunglas/httpsfv"
 )
 
-type Dialer struct {
+type Transport struct {
 	// Config is the WebTransport configuration used for new sessions.
 	Config *Config
 
@@ -50,11 +50,11 @@ type Dialer struct {
 	initOnce sync.Once
 }
 
-func (d *Dialer) init() {
+func (d *Transport) init() {
 	d.ctx, d.ctxCancel = context.WithCancel(context.Background())
 }
 
-func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
+func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
 	d.initOnce.Do(func() { d.init() })
 	var config Config
 	if d.Config != nil {
@@ -149,7 +149,7 @@ func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*
 	return rsp, sess, nil
 }
 
-func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request, config Config) (*http.Response, *Session, error) {
+func (d *Transport) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request, config Config) (*http.Response, *Session, error) {
 	timeout := d.StreamReorderingTimeout
 	if timeout == 0 {
 		timeout = 5 * time.Second
@@ -289,7 +289,7 @@ func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *qui
 	return rsp, sess, nil
 }
 
-func (d *Dialer) negotiateProtocol(theirs []string) (string, error) {
+func (d *Transport) negotiateProtocol(theirs []string) (string, error) {
 	negotiatedProtocolItem, err := httpsfv.UnmarshalItem(theirs)
 	if err != nil {
 		return "", fmt.Errorf("webtransport: invalid WT-Protocol header: %w", err)
@@ -304,7 +304,7 @@ func (d *Dialer) negotiateProtocol(theirs []string) (string, error) {
 	return negotiatedProtocol, nil
 }
 
-func (d *Dialer) Close() error {
+func (d *Transport) Close() error {
 	d.ctxCancel()
 	return nil
 }

--- a/transport.go
+++ b/transport.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dunglas/httpsfv"
 )
 
+// A Transport configures WebTransport clients.
 type Transport struct {
 	// Config is the WebTransport configuration used for new sessions.
 	Config *Config
@@ -54,6 +55,8 @@ func (d *Transport) init() {
 	d.ctx, d.ctxCancel = context.WithCancel(context.Background())
 }
 
+// Dial establishes a WebTransport session on a new QUIC connection.
+// The QUIC connection is closed when the returned session is closed.
 func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
 	d.initOnce.Do(func() { d.init() })
 	var config Config
@@ -304,6 +307,7 @@ func (d *Transport) negotiateProtocol(theirs []string) (string, error) {
 	return negotiatedProtocol, nil
 }
 
+// Close cancels session establishment waiting for peer HTTP/3 settings.
 func (d *Transport) Close() error {
 	d.ctxCancel()
 	return nil

--- a/transport_test.go
+++ b/transport_test.go
@@ -92,7 +92,7 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 		}
 	}()
 
-	d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+	d := webtransport.Transport{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
 	_, _, err = d.Dial(context.Background(), fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port), nil)
 	require.Error(t, err)
 	var sErr error
@@ -119,7 +119,7 @@ func TestClientClosesConnectionForInvalidSessionID(t *testing.T) {
 	}{{"bidirectional", webTransportFrameType}, {"unidirectional", webTransportUniStreamType}} {
 		t.Run(tt.name, func(t *testing.T) {
 			go func() {
-				d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+				d := webtransport.Transport{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
 				_, _, _ = d.Dial(context.Background(), addr, nil)
 			}()
 
@@ -179,7 +179,7 @@ func TestClientWaitForSettingsTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	errChan := make(chan error)
 	go func() {
-		d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+		d := webtransport.Transport{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
 		_, _, err := d.Dial(ctx, fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port), nil)
 		errChan <- err
 	}()
@@ -273,7 +273,7 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 				connChan <- conn
 			}()
 
-			d := webtransport.Dialer{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
+			d := webtransport.Transport{TLSClientConfig: &tls.Config{RootCAs: webtransport.CertPool}}
 			_, _, err = d.Dial(context.Background(), fmt.Sprintf("https://localhost:%d", ln.Addr().(*net.UDPAddr).Port), nil)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.errorStr)


### PR DESCRIPTION
This mirrors the API recently introduced in masque-go and connect-ip-go.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `Dialer` to `Transport` in the webtransport client API
> Renames the `webtransport.Dialer` type to `webtransport.Transport` in [transport.go](https://github.com/quic-go/webtransport-go/pull/343/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f) and updates all call sites across integration tests, examples, and interop code. No fields, method signatures, or behavior are changed — this is a pure rename. The test file `client_test.go` is also renamed to [transport_test.go](https://github.com/quic-go/webtransport-go/pull/343/files#diff-89ae70865ace384239355ee0c882acef79b281a7c88c53c22058d75941cd2643).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db7df5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the public `Dialer` client type with `Transport` for establishing WebTransport connections.
  * Updated the connection lifecycle, including session setup, protocol negotiation validation, and unified close/cancellation behavior.
* **Tests**
  * Updated integration and unit tests to construct and use `Transport` instead of `Dialer`.
* **Documentation / Examples**
  * Updated example and interoperability client code to use the new `Transport` API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->