### PR TITLE
introduce a ClientConn, make it possible to pool sessions

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -1,0 +1,268 @@
+package webtransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/dunglas/httpsfv"
+)
+
+// A ClientConn is a WebTransport client connection.
+// Multiple sessions can be established concurrently on a ClientConn.
+type ClientConn struct {
+	conn                 *quic.Conn
+	clientConn           *http3.RawClientConn
+	sessMgr              *sessionManager
+	config               Config
+	applicationProtocols []string
+	transportCtx         context.Context
+}
+
+var _ http.RoundTripper = &ClientConn{}
+
+// NewClientConn creates a WebTransport client connection on an existing QUIC connection.
+// The QUIC connection must have datagrams and stream reset partial delivery enabled.
+// It must only be called once per QUIC connection.
+// The caller owns the QUIC connection and closes it when done.
+func (d *Transport) NewClientConn(qconn *quic.Conn) (*ClientConn, error) {
+	d.initOnce.Do(func() { d.init() })
+	state := qconn.ConnectionState()
+	if !state.SupportsDatagrams.Local {
+		return nil, errors.New("webtransport: DATAGRAM support required, enable it via QUICConfig.EnableDatagrams")
+	}
+	if !state.SupportsStreamResetPartialDelivery.Local {
+		return nil, errors.New("webtransport: stream reset partial delivery required, enable it via QUICConfig.EnableStreamResetPartialDelivery")
+	}
+
+	var config Config
+	if d.Config != nil {
+		config = *d.Config
+	}
+	additionalSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
+	config.addSettings(additionalSettings)
+	tr := &http3.Transport{EnableDatagrams: true, AdditionalSettings: additionalSettings}
+
+	timeout := d.StreamReorderingTimeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	sessMgr := newSessionManager(timeout)
+	context.AfterFunc(qconn.Context(), sessMgr.Close)
+
+	c := &ClientConn{
+		conn:                 qconn,
+		clientConn:           tr.NewRawClientConn(qconn),
+		sessMgr:              sessMgr,
+		config:               config,
+		applicationProtocols: slices.Clone(d.ApplicationProtocols),
+		transportCtx:         d.ctx,
+	}
+
+	go func() {
+		for {
+			str, err := qconn.AcceptStream(context.Background())
+			if err != nil {
+				return
+			}
+
+			go func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportFrameType {
+					c.clientConn.HandleBidirectionalStream(str)
+					return
+				}
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
+				// read the frame type (already peeked above)
+				if _, err := quicvarint.Read(r); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(r)
+				if err != nil {
+					return
+				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				c.sessMgr.AddStream(str, sessionID(id), r.BytesRead)
+			}()
+		}
+	}()
+
+	go func() {
+		for {
+			str, err := qconn.AcceptUniStream(context.Background())
+			if err != nil {
+				return
+			}
+
+			go func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportUniStreamType {
+					c.clientConn.HandleUnidirectionalStream(str)
+					return
+				}
+				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
+				// read the stream type (already peeked above)
+				if _, err := quicvarint.Read(r); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(r)
+				if err != nil {
+					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				c.sessMgr.AddUniStream(str, sessionID(id), r.BytesRead)
+			}()
+		}
+	}()
+
+	return c, nil
+}
+
+// Dial establishes a new WebTransport session on the client connection.
+// Closing the session doesn't close the underlying QUIC connection or other sessions.
+func (c *ClientConn) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.dial(ctx, u, reqHdr)
+}
+
+func (c *ClientConn) dial(ctx context.Context, u *url.URL, reqHdr http.Header) (*http.Response, *Session, error) {
+	if reqHdr == nil {
+		reqHdr = make(http.Header)
+	} else {
+		reqHdr = reqHdr.Clone()
+	}
+	if len(c.applicationProtocols) > 0 && reqHdr.Get(wtAvailableProtocolsHeader) == "" {
+		list := make(httpsfv.List, 0, len(c.applicationProtocols))
+		for _, protocol := range c.applicationProtocols {
+			list = append(list, httpsfv.NewItem(protocol))
+		}
+		protocols, err := httpsfv.Marshal(list)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal application protocols: %w", err)
+		}
+		reqHdr.Set(wtAvailableProtocolsHeader, protocols)
+	}
+	req := (&http.Request{
+		Method: http.MethodConnect,
+		Header: reqHdr,
+		Proto:  protocolHeader,
+		Host:   u.Host,
+		URL:    u,
+	}).WithContext(ctx)
+
+	select {
+	case <-c.clientConn.ReceivedSettings():
+	case <-ctx.Done():
+		return nil, nil, fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))
+	case <-c.transportCtx.Done():
+		return nil, nil, context.Cause(c.transportCtx)
+	}
+	settings := c.clientConn.Settings()
+	if !settings.EnableExtendedConnect {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable Extended CONNECT"}
+	}
+	if !settings.EnableDatagrams {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable HTTP/3 datagram support"}
+	}
+	if settings.Other == nil {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
+	}
+	// any non-zero value for SETTINGS_WT_ENABLED means that WebTransport is enabled
+	s, ok := settings.Other[settingsWebTransportEnabled]
+	if !ok || s == 0 {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
+	}
+
+	requestStr, err := c.clientConn.OpenRequestStream(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := requestStr.SendRequestHeader(req); err != nil {
+		requestStr.CancelRead(quic.StreamErrorCode(http3.ErrCodeRequestCanceled))
+		requestStr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeRequestCanceled))
+		return nil, nil, err
+	}
+	// TODO(#136): create the session to allow optimistic opening of streams and sending of datagrams
+	rsp, err := requestStr.ReadResponse()
+	if err != nil {
+		requestStr.CancelRead(quic.StreamErrorCode(http3.ErrCodeRequestCanceled))
+		requestStr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeRequestCanceled))
+		return nil, nil, err
+	}
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+		_ = requestStr.Close()
+		return rsp, nil, fmt.Errorf("received status %d", rsp.StatusCode)
+	}
+	sessID := sessionID(requestStr.StreamID())
+	var protocol string
+	// Don't send WT_ALPN_ERROR if WT-Protocol is absent: the server didn't
+	// negotiate a protocol. Send it only when WT-Protocol is present but invalid.
+	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
+		var err error
+		protocol, err = c.negotiateProtocol(protocolHeader)
+		if err != nil {
+			sessErr := &SessionError{ErrorCode: WTALPNErrorCode, Message: err.Error()}
+			_ = closeSessionStream(
+				requestStr,
+				closeSessionCapsule{ErrorCode: sessErr.ErrorCode, Message: sessErr.Message},
+			)
+			return rsp, nil, sessErr
+		}
+	}
+	sess := newSession(
+		context.WithoutCancel(ctx),
+		sessID,
+		c.conn,
+		requestStr,
+		protocol,
+		c.config.sessionFlowControl(settings),
+	)
+	c.sessMgr.AddSession(sessID, sess)
+	return rsp, sess, nil
+}
+
+// RoundTrip executes an HTTP request on the underlying HTTP/3 connection.
+func (c *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return c.clientConn.RoundTrip(req)
+}
+
+func (c *ClientConn) negotiateProtocol(theirs []string) (string, error) {
+	negotiatedProtocolItem, err := httpsfv.UnmarshalItem(theirs)
+	if err != nil {
+		return "", fmt.Errorf("webtransport: invalid WT-Protocol header: %w", err)
+	}
+	negotiatedProtocol, ok := negotiatedProtocolItem.Value.(string)
+	if !ok {
+		return "", errors.New("webtransport: invalid WT-Protocol header: value is not a string")
+	}
+	if !slices.Contains(c.applicationProtocols, negotiatedProtocol) {
+		return "", fmt.Errorf("webtransport: server selected application protocol %q that wasn't offered", negotiatedProtocol)
+	}
+	return negotiatedProtocol, nil
+}

--- a/transport.go
+++ b/transport.go
@@ -4,21 +4,18 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"sync"
 	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/dunglas/httpsfv"
 )
 
 // A Transport configures WebTransport clients.
+// Dial creates a new QUIC connection for each session. To establish multiple
+// sessions on one QUIC connection, use NewClientConn.
 type Transport struct {
 	// Config is the WebTransport configuration used for new sessions.
 	Config *Config
@@ -59,11 +56,6 @@ func (d *Transport) init() {
 // The QUIC connection is closed when the returned session is closed.
 func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
 	d.initOnce.Do(func() { d.init() })
-	var config Config
-	if d.Config != nil {
-		config = *d.Config
-	}
-
 	quicConf := d.QUICConfig
 	if quicConf == nil {
 		quicConf = &quic.Config{
@@ -93,29 +85,6 @@ func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header)
 	if err != nil {
 		return nil, nil, err
 	}
-	if reqHdr == nil {
-		reqHdr = http.Header{}
-	}
-	if len(d.ApplicationProtocols) > 0 && reqHdr.Get(wtAvailableProtocolsHeader) == "" {
-		list := httpsfv.List{}
-		for _, protocol := range d.ApplicationProtocols {
-			list = append(list, httpsfv.NewItem(protocol))
-		}
-		protocols, err := httpsfv.Marshal(list)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal application protocols: %w", err)
-		}
-		reqHdr.Set(wtAvailableProtocolsHeader, protocols)
-	}
-
-	req := &http.Request{
-		Method: http.MethodConnect,
-		Header: reqHdr,
-		Proto:  protocolHeader,
-		Host:   u.Host,
-		URL:    u,
-	}
-	req = req.WithContext(ctx)
 
 	dialAddr := d.DialAddr
 	if dialAddr == nil {
@@ -126,13 +95,12 @@ func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header)
 		return nil, nil, err
 	}
 
-	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
-	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
-	// for its supported draft version, so the server can negotiate the version.
-	additionalSettings := map[uint64]uint64{settingsWebTransportEnabled: 1}
-	config.addSettings(additionalSettings)
-	tr := &http3.Transport{EnableDatagrams: true, AdditionalSettings: additionalSettings}
-	rsp, sess, err := d.handleConn(ctx, tr, qconn, req, config)
+	clientConn, err := d.NewClientConn(qconn)
+	if err != nil {
+		qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "")
+		return nil, nil, err
+	}
+	rsp, sess, err := clientConn.dial(ctx, u, reqHdr)
 	if err != nil {
 		var msg string
 		code := quic.ApplicationErrorCode(http3.ErrCodeNoError)
@@ -142,172 +110,16 @@ func (d *Transport) Dial(ctx context.Context, urlStr string, reqHdr http.Header)
 			msg = reqErr.Message
 		}
 		qconn.CloseWithError(code, msg)
-		tr.Close()
 		return rsp, nil, err
 	}
 	context.AfterFunc(sess.Context(), func() {
 		qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "")
-		tr.Close()
 	})
 	return rsp, sess, nil
 }
 
-func (d *Transport) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request, config Config) (*http.Response, *Session, error) {
-	timeout := d.StreamReorderingTimeout
-	if timeout == 0 {
-		timeout = 5 * time.Second
-	}
-	sessMgr := newSessionManager(timeout)
-	context.AfterFunc(qconn.Context(), sessMgr.Close)
-
-	conn := tr.NewRawClientConn(qconn)
-
-	go func() {
-		for {
-			str, err := qconn.AcceptStream(context.Background())
-			if err != nil {
-				return
-			}
-
-			go func() {
-				typ, err := quicvarint.Peek(str)
-				if err != nil {
-					return
-				}
-				if typ != webTransportFrameType {
-					conn.HandleBidirectionalStream(str)
-					return
-				}
-				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
-				// read the frame type (already peeked above)
-				if _, err := quicvarint.Read(r); err != nil {
-					return
-				}
-				// read the session ID
-				id, err := quicvarint.Read(r)
-				if err != nil {
-					return
-				}
-				if !isValidSessionID(id) {
-					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
-					return
-				}
-				sessMgr.AddStream(str, sessionID(id), r.BytesRead)
-			}()
-		}
-	}()
-
-	go func() {
-		for {
-			str, err := qconn.AcceptUniStream(context.Background())
-			if err != nil {
-				return
-			}
-
-			go func() {
-				typ, err := quicvarint.Peek(str)
-				if err != nil {
-					return
-				}
-				if typ != webTransportUniStreamType {
-					conn.HandleUnidirectionalStream(str)
-					return
-				}
-				r := &byteCountingReader{ByteReader: quicvarint.NewReader(str)}
-				// read the stream type (already peeked above)
-				if _, err := quicvarint.Read(r); err != nil {
-					return
-				}
-				// read the session ID
-				id, err := quicvarint.Read(r)
-				if err != nil {
-					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
-					return
-				}
-				if !isValidSessionID(id) {
-					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
-					return
-				}
-				sessMgr.AddUniStream(str, sessionID(id), r.BytesRead)
-			}()
-		}
-	}()
-
-	select {
-	case <-conn.ReceivedSettings():
-	case <-ctx.Done():
-		return nil, nil, fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))
-	case <-d.ctx.Done():
-		return nil, nil, context.Cause(d.ctx)
-	}
-	settings := conn.Settings()
-	if !settings.EnableExtendedConnect {
-		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable Extended CONNECT"}
-	}
-	if !settings.EnableDatagrams {
-		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable HTTP/3 datagram support"}
-	}
-	if settings.Other == nil {
-		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
-	}
-	// any non-zero value for SETTINGS_WT_ENABLED means that WebTransport is enabled
-	s, ok := settings.Other[settingsWebTransportEnabled]
-	if !ok || s == 0 {
-		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
-	}
-
-	requestStr, err := conn.OpenRequestStream(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := requestStr.SendRequestHeader(req); err != nil {
-		return nil, nil, err
-	}
-	// TODO(#136): create the session to allow optimistic opening of streams and sending of datagrams
-	rsp, err := requestStr.ReadResponse()
-	if err != nil {
-		return nil, nil, err
-	}
-	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
-		return rsp, nil, fmt.Errorf("received status %d", rsp.StatusCode)
-	}
-	sessID := sessionID(requestStr.StreamID())
-	var protocol string
-	// Don't send WT_ALPN_ERROR if WT-Protocol is absent: the server didn't
-	// negotiate a protocol. Send it only when WT-Protocol is present but invalid.
-	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
-		var err error
-		protocol, err = d.negotiateProtocol(protocolHeader)
-		if err != nil {
-			sessErr := &SessionError{ErrorCode: WTALPNErrorCode, Message: err.Error()}
-			_ = closeSessionStream(
-				requestStr,
-				closeSessionCapsule{ErrorCode: sessErr.ErrorCode, Message: sessErr.Message},
-			)
-			return rsp, nil, sessErr
-		}
-	}
-	sess := newSession(context.WithoutCancel(ctx), sessID, qconn, requestStr, protocol, config.sessionFlowControl(settings))
-	sessMgr.AddSession(sessID, sess)
-	return rsp, sess, nil
-}
-
-func (d *Transport) negotiateProtocol(theirs []string) (string, error) {
-	negotiatedProtocolItem, err := httpsfv.UnmarshalItem(theirs)
-	if err != nil {
-		return "", fmt.Errorf("webtransport: invalid WT-Protocol header: %w", err)
-	}
-	negotiatedProtocol, ok := negotiatedProtocolItem.Value.(string)
-	if !ok {
-		return "", errors.New("webtransport: invalid WT-Protocol header: value is not a string")
-	}
-	if !slices.Contains(d.ApplicationProtocols, negotiatedProtocol) {
-		return "", fmt.Errorf("webtransport: server selected application protocol %q that wasn't offered", negotiatedProtocol)
-	}
-	return negotiatedProtocol, nil
-}
-
 // Close cancels session establishment waiting for peer HTTP/3 settings.
+// It doesn't close established sessions or QUIC connections passed to NewClientConn.
 func (d *Transport) Close() error {
 	d.ctxCancel()
 	return nil


### PR DESCRIPTION
Fixes #147.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `ClientConn` to support multiple WebTransport sessions on a single QUIC connection
> - Adds a new `ClientConn` type in [client_conn.go](https://github.com/quic-go/webtransport-go/pull/344/files#diff-51d33eb9510addccb9b49083f75f592a7d3139d2a9c7c3c06fecf8fae96cd36a) that wraps an existing `*quic.Conn` and exposes a `Dial` method to open multiple concurrent WebTransport sessions without creating a new QUIC connection per session.
> - Adds `Transport.NewClientConn` to construct a `ClientConn` from an existing QUIC connection, validating DATAGRAMS and stream reset capabilities, setting up HTTP/3 transport internals, and dispatching incoming streams to the session manager.
> - Refactors `Transport.Dial` in [transport.go](https://github.com/quic-go/webtransport-go/pull/344/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f) to delegate session establishment to `ClientConn.dial` internally, keeping the existing API unchanged.
> - Behavioral Change: `Transport.Close` no longer closes QUIC connections passed to `NewClientConn`; only waiting-for-settings goroutines are cancelled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89d2b55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client connection support for establishing WebTransport sessions over existing QUIC connections.
  * Added support for dialing sessions with protocol negotiation and capability validation.
  * Added HTTP request forwarding through the client connection.

* **Bug Fixes**
  * Improved connection cleanup when session establishment fails or sessions end.
  * Added handling for unsupported capabilities and invalid session identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->