### PR TITLE
watch for connection closure while waiting for SETTINGS

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -180,6 +180,8 @@ func (c *ClientConn) dial(ctx context.Context, u *url.URL, reqHdr http.Header) (
 	case <-c.clientConn.ReceivedSettings():
 	case <-ctx.Done():
 		return nil, nil, fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))
+	case <-c.conn.Context().Done():
+		return nil, nil, context.Cause(c.conn.Context())
 	case <-c.transportCtx.Done():
 		return nil, nil, context.Cause(c.transportCtx)
 	}

--- a/server.go
+++ b/server.go
@@ -408,6 +408,8 @@ func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, erro
 	defer timer.Stop()
 	select {
 	case <-settingser.ReceivedSettings():
+	case <-conn.Context().Done():
+		return nil, context.Cause(conn.Context())
 	case <-timer.C:
 		return nil, errors.New("webtransport: didn't receive the client's SETTINGS on time")
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix connection closure not being detected while waiting for HTTP/3 SETTINGS
Both `ClientConn.dial` and `Server.Upgrade` previously blocked waiting for HTTP/3 SETTINGS with no way to detect if the underlying QUIC connection closed. A new `case` on `conn.Context().Done()` is added to the select in each path, returning `context.Cause(conn.Context())` immediately when the connection ends.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f8f1b9.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling during client setup.
  * Server upgrades now return promptly when the underlying connection is canceled or terminated.
  * Prevented unnecessary waiting when connections close before HTTP/3 settings are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->