### PR TITLE
expose QUIC stream IDs on WebTransport streams

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -12,6 +12,7 @@ import (
 
 type quicReceiveStream interface {
 	io.Reader
+	StreamID() quic.StreamID
 	CancelRead(quic.StreamErrorCode)
 	SetReceiveFinalSizeCallback(func(int64))
 	SetReadDeadline(time.Time) error
@@ -62,6 +63,11 @@ func newReceiveStream(
 		str.SetReceiveFinalSizeCallback(s.onReceiveFinalSize)
 	}
 	return s
+}
+
+// StreamID returns the ID of the underlying QUIC stream.
+func (s *ReceiveStream) StreamID() quic.StreamID {
+	return s.str.StreamID()
 }
 
 // Read reads data from the stream.

--- a/send_stream.go
+++ b/send_stream.go
@@ -14,6 +14,7 @@ import (
 type quicSendStream interface {
 	io.WriteCloser
 	WriteWithLimit([]byte, func(int) int) (int, error)
+	StreamID() quic.StreamID
 	CancelWrite(quic.StreamErrorCode)
 	Context() context.Context
 	SetWriteDeadline(time.Time) error
@@ -66,6 +67,11 @@ func newSendStream(
 		streamHdr:    hdr,
 		onClose:      onClose,
 	}
+}
+
+// StreamID returns the ID of the underlying QUIC stream.
+func (s *SendStream) StreamID() quic.StreamID {
+	return s.str.StreamID()
 }
 
 // Write writes data to the stream.

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -243,6 +243,7 @@ func (s *blockingHeaderStream) Write(b []byte) (int, error) {
 }
 
 func (*blockingHeaderStream) Close() error                     { return nil }
+func (*blockingHeaderStream) StreamID() quic.StreamID          { return 0 }
 func (*blockingHeaderStream) CancelWrite(quic.StreamErrorCode) {}
 func (*blockingHeaderStream) Context() context.Context         { return context.Background() }
 func (*blockingHeaderStream) SetWriteDeadline(time.Time) error { return nil }

--- a/stream.go
+++ b/stream.go
@@ -37,6 +37,11 @@ func newStream(
 	return s
 }
 
+// StreamID returns the ID of the underlying QUIC stream.
+func (s *Stream) StreamID() quic.StreamID {
+	return s.recvStr.StreamID()
+}
+
 // Write writes data to the stream.
 // Write can be made to time out using [Stream.SetWriteDeadline] or [Stream.SetDeadline].
 // If the stream was canceled, the error is a [StreamError].


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Expose `StreamID()` on WebTransport `SendStream`, `ReceiveStream`, and `Stream`
Adds a `StreamID() quic.StreamID` method to all three WebTransport stream types by delegating to the underlying QUIC stream. The `quicSendStream` and `quicReceiveStream` internal interfaces are updated to require `StreamID()`, and test doubles are updated to match.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43b5a7f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the underlying QUIC stream identifier for send, receive, and bidirectional streams.
  - Stream identifiers can now be retrieved directly through the public stream APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->