### PR TITLE
use TryWriteAll for close session capsules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/dunglas/httpsfv v1.1.0
-	github.com/quic-go/quic-go v0.61.0
+	github.com/quic-go/quic-go v0.61.1-0.20260726092802-47961f39aaeb
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4
 github.com/quic-go/go-ossfuzz-seeds v0.1.0/go.mod h1:3IOHRbJIc+L6YKMwfDtJAM9Vj9k0YY4muhuyUYk5tbk=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.61.0 h1:ui88A53s8MSVYLC56en0KQ17HARk+9986Dn0SBfKNvA=
-github.com/quic-go/quic-go v0.61.0/go.mod h1:9So2anK4Tp22URSQq00k+Vo2PNkle96ycDPDHL4s9vs=
+github.com/quic-go/quic-go v0.61.1-0.20260726092802-47961f39aaeb h1:oFcGBAOkCZrthOq2QLnC4lW2I1NMcB9ghZANDaIa4vU=
+github.com/quic-go/quic-go v0.61.1-0.20260726092802-47961f39aaeb/go.mod h1:9So2anK4Tp22URSQq00k+Vo2PNkle96ycDPDHL4s9vs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/session.go
+++ b/session.go
@@ -22,6 +22,7 @@ type http3Stream interface {
 	CancelRead(quic.StreamErrorCode)
 	CancelWrite(quic.StreamErrorCode)
 	SetWriteDeadline(time.Time) error
+	TryWriteAll([]byte) error
 }
 
 var (
@@ -387,11 +388,7 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 }
 
 func closeSessionStream(str http3Stream, closeCapsule closeSessionCapsule) error {
-	// Optimistically send the WT_CLOSE_SESSION Capsule:
-	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
-	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
-	str.SetWriteDeadline(time.Now().Add(closeSessionTimeout))
-	if _, err := str.Write(closeCapsule.Append(nil)); err != nil {
+	if err := str.TryWriteAll(closeCapsule.Append(nil)); err != nil {
 		str.CancelWrite(WTSessionGoneErrorCode)
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -31,6 +31,7 @@ func (s mockHTTP3Stream) SendDatagram([]byte) error                       { retu
 func (s mockHTTP3Stream) CancelRead(quic.StreamErrorCode)                 {}
 func (s mockHTTP3Stream) CancelWrite(quic.StreamErrorCode)                {}
 func (s mockHTTP3Stream) SetWriteDeadline(time.Time) error                { return nil }
+func (s mockHTTP3Stream) TryWriteAll([]byte) error                        { return nil }
 
 type quicHTTP3Stream struct{ *quic.Stream }
 


### PR DESCRIPTION
Blocked on the quic-go v0.62.0 release.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `TryWriteAll` for writing close session capsules in `closeSessionStream`
> Replaces the write deadline + `Write` pattern in `closeSessionStream` with a call to `str.TryWriteAll` when sending close capsules. Also updates the `http3Stream` interface to include `TryWriteAll([]byte) error` and bumps `github.com/quic-go/quic-go` to a pre-release version that exposes this method.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a002c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when closing sessions by ensuring the close signal is sent promptly.
  - Added safer handling when the session close signal cannot be written, including appropriate stream cancellation.

- **Maintenance**
  - Updated the QUIC transport dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->