### PR TITLE
ci: update ChromeDriver to 151.0.7922.47 for interop test

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -6,6 +6,8 @@ on: [push, pull_request]
 jobs:
   interop:
     runs-on: "ubuntu-latest"
+    env:
+      CHROME_VERSION: '151.0.7922.47'
     strategy:
       fail-fast: false
       matrix:
@@ -15,10 +17,10 @@ jobs:
     - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       id: setup-chrome
       with:
-        chrome-version: '142.0.7444.162'
+        chrome-version: ${{ env.CHROME_VERSION }}
     - uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c # v3.0.0
       with:
-        chromedriver-version: '142.0.7444.162'
+        chromedriver-version: ${{ env.CHROME_VERSION }}
     - uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update ChromeDriver to 151.0.7922.47 in interop CI workflow
> Bumps Chrome and ChromeDriver from `142.0.7444.162` to `151.0.7922.47` in [interop.yml](.github/workflows/interop.yml). Extracts the version into a top-level `CHROME_VERSION` env variable so both `browser-actions/setup-chrome` and `nanasess/setup-chromedriver` stay in sync automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82c27ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated browser testing environment to use a newer Chrome/ChromeDriver version.
  * Improved compatibility by keeping the browser and driver versions in sync for interoperability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->