### PR TITLE
ci: use deterministic Chrome versions for interop test

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -12,6 +12,10 @@ jobs:
         go: [ "1.25.x", "1.26.x" ]
     steps:
     - uses: actions/checkout@v7
+    - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
+      id: setup-chrome
+      with:
+        chrome-version: '142.0.7444.162'
     - uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c # v3.0.0
       with:
         chromedriver-version: '142.0.7444.162'
@@ -26,6 +30,8 @@ jobs:
     - name: Install Python dependencies
       run: pip install -r interop_chrome/requirements.txt
     - name: Run interop tests
+      env:
+        CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
       run: |
         ./interopserver &
         timeout 120 python interop_chrome/interop.py

--- a/interop_chrome/interop.py
+++ b/interop_chrome/interop.py
@@ -26,8 +26,12 @@ options.add_argument("--origin-to-force-quic-on=localhost:12345")
 options.add_argument("--host-resolver-rules='MAP localhost:12345 127.0.0.1:12345'")
 options.set_capability("goog:loggingPrefs", {"browser": "ALL"})
 
+chromedriver_path = shutil.which("chromedriver")
+if chromedriver_path is None:
+    raise RuntimeError("chromedriver not found on PATH; install chromedriver or use an environment that provides it")
+
 driver = webdriver.Chrome(
-    service=Service(shutil.which("chromedriver")),
+    service=Service(chromedriver_path),
     options=options,
 )
 

--- a/interop_chrome/interop.py
+++ b/interop_chrome/interop.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import shutil
 import sys
 
@@ -11,8 +12,8 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException
 
-chrome_loc = "/usr/bin/google-chrome"
-if sys.platform == "darwin":
+chrome_loc = os.environ.get("CHROME_PATH", "/usr/bin/google-chrome")
+if sys.platform == "darwin" and "CHROME_PATH" not in os.environ:
     chrome_loc = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
 options = webdriver.ChromeOptions()

--- a/interop_chrome/interop.py
+++ b/interop_chrome/interop.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
+import shutil
 import sys
 
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
-from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
@@ -26,7 +26,7 @@ options.add_argument("--host-resolver-rules='MAP localhost:12345 127.0.0.1:12345
 options.set_capability("goog:loggingPrefs", {"browser": "ALL"})
 
 driver = webdriver.Chrome(
-    service=Service(ChromeDriverManager().install()),
+    service=Service(shutil.which("chromedriver")),
     options=options,
 )
 

--- a/interop_chrome/requirements.txt
+++ b/interop_chrome/requirements.txt
@@ -1,3 +1,2 @@
 packaging
 selenium
-webdriver-manager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chrome WebDriver startup by using an installed system driver, reducing reliance on automatic driver downloads.
* **Chores**
  * Removed the unnecessary driver-management dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Chrome to a deterministic version in the interop CI test
> - Adds a `browser-actions/setup-chrome@v2.1.2` step in [interop.yml](.github/workflows/interop.yml) that installs Chrome 142.0.7444.162 and exports `CHROME_PATH` to the test step.
> - Updates [interop.py](interop_chrome/interop.py) to read `CHROME_PATH` from the environment (falling back to `/usr/bin/google-chrome`) and resolve `chromedriver` via `shutil.which` instead of auto-downloading it with `webdriver-manager`.
> - Removes the `webdriver-manager` dependency from [requirements.txt](interop_chrome/requirements.txt).
> - Risk: `chromedriver` must now be present on `PATH` in CI; if it is missing, the test raises a `RuntimeError` instead of downloading it automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b214bf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->