### PR TITLE
check server QUIC capabilities when dialing

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -30,7 +30,7 @@ type ClientConn struct {
 var _ http.RoundTripper = &ClientConn{}
 
 // NewClientConn creates a WebTransport client connection on an existing QUIC connection.
-// The QUIC connection must have datagrams and stream reset partial delivery enabled.
+// The QUIC connection must have datagrams and stream reset partial delivery enabled on both endpoints.
 // It must only be called once per QUIC connection.
 // The caller owns the QUIC connection and closes it when done.
 func (d *Transport) NewClientConn(qconn *quic.Conn) (*ClientConn, error) {
@@ -175,6 +175,25 @@ func (c *ClientConn) dial(ctx context.Context, u *url.URL, reqHdr http.Header) (
 		Host:   u.Host,
 		URL:    u,
 	}).WithContext(ctx)
+
+	// wait for the QUIC handshake to complete
+	select {
+	case <-c.conn.HandshakeComplete():
+	case <-ctx.Done():
+		return nil, nil, fmt.Errorf("error waiting for QUIC handshake: %w", context.Cause(ctx))
+	case <-c.conn.Context().Done():
+		return nil, nil, context.Cause(c.conn.Context())
+	case <-c.transportCtx.Done():
+		return nil, nil, context.Cause(c.transportCtx)
+	}
+
+	state := c.conn.ConnectionState()
+	if !state.SupportsDatagrams.Remote {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable QUIC datagram support"}
+	}
+	if !state.SupportsStreamResetPartialDelivery.Remote {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable QUIC stream reset partial delivery"}
+	}
 
 	select {
 	case <-c.clientConn.ReceivedSettings():

--- a/errors.go
+++ b/errors.go
@@ -86,7 +86,7 @@ func (e *SessionError) Is(target error) bool {
 }
 
 // RequirementsNotMetError is returned when the peer doesn't advertise
-// the required HTTP/3 or WebTransport capabilities.
+// the required QUIC, HTTP/3 or WebTransport capabilities.
 type RequirementsNotMetError struct {
 	Message string
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -46,7 +46,11 @@ func appendSettingsFrame(b []byte, values map[uint64]uint64) []byte {
 }
 
 func TestClientInvalidResponseHandling(t *testing.T) {
-	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true})
+	ln, err := quic.ListenAddr(
+		"localhost:0",
+		webtransport.TLSConf,
+		&quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+	)
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -107,6 +111,53 @@ func TestClientInvalidResponseHandling(t *testing.T) {
 	require.Equal(t, http3.ErrCodeFrameUnexpected, http3.ErrCode(appErr.ErrorCode))
 }
 
+func TestClientConnChecksServerQUICSupportOnDial(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		config     *quic.Config
+		wantErrMsg string
+	}{
+		{
+			name:       "datagrams",
+			config:     &quic.Config{EnableStreamResetPartialDelivery: true},
+			wantErrMsg: "server didn't enable QUIC datagram support",
+		},
+		{
+			name:       "stream reset partial delivery",
+			config:     &quic.Config{EnableDatagrams: true},
+			wantErrMsg: "server didn't enable QUIC stream reset partial delivery",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, tt.config)
+			require.NoError(t, err)
+			defer ln.Close()
+
+			qconn, err := quic.DialAddr(
+				t.Context(),
+				ln.Addr().String(),
+				&tls.Config{
+					RootCAs:    webtransport.CertPool,
+					ServerName: "localhost",
+					NextProtos: []string{http3.NextProtoH3},
+				},
+				&quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+			)
+			require.NoError(t, err)
+			defer qconn.CloseWithError(0, "")
+
+			tr := &webtransport.Transport{}
+			defer tr.Close()
+			conn, err := tr.NewClientConn(qconn)
+			require.NoError(t, err)
+			_, _, err = conn.Dial(t.Context(), "https://localhost", nil)
+			require.ErrorContains(t, err, tt.wantErrMsg)
+			var reqErr *webtransport.RequirementsNotMetError
+			require.ErrorAs(t, err, &reqErr)
+		})
+	}
+}
+
 func TestClientClosesConnectionForInvalidSessionID(t *testing.T) {
 	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true})
 	require.NoError(t, err)
@@ -163,7 +214,7 @@ func TestClientClosesConnectionForInvalidSessionID(t *testing.T) {
 }
 
 func TestClientWaitForSettingsTimeout(t *testing.T) {
-	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true})
+	ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true})
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -249,7 +300,7 @@ func TestClientInvalidSettingsHandling(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true})
+			ln, err := quic.ListenAddr("localhost:0", webtransport.TLSConf, &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true})
 			require.NoError(t, err)
 			defer ln.Close()
 


### PR DESCRIPTION
Fixes #345.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Check server QUIC capabilities when dialing in `ClientConn.dial`
> - `ClientConn.dial` now waits for the QUIC handshake to complete before proceeding, then checks that the server has enabled QUIC datagrams and stream reset partial delivery.
> - If either capability is missing, `dial` returns a `RequirementsNotMetError` with a descriptive message.
> - Behavioral Change: servers that don't advertise both QUIC capabilities will now cause `Dial` to fail immediately rather than proceeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c48da43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - WebTransport connections now wait for the QUIC handshake to complete before proceeding.
  - Connections are rejected early when the server lacks required QUIC datagram or stream reset capabilities.
  - Connection cancellation and transport errors now provide more informative failure details.

- **Documentation**
  - Clarified the required QUIC and HTTP/3/WebTransport capabilities for establishing a connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->